### PR TITLE
Fix trailing text in ConversationManager

### DIFF
--- a/src/lib/ConversationManager.ts
+++ b/src/lib/ConversationManager.ts
@@ -350,5 +350,3 @@ export class ConversationManager {
          return summary;
     }
 }
-
- // REMOVED: Redundant export statement


### PR DESCRIPTION
## Summary
- remove stray prompt snippet from the end of `ConversationManager.ts`

## Testing
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e6264dbdc83309ed0cabd3ce81b9a