### PR TITLE
Improve commit message generation

### DIFF
--- a/src/lib/__tests__/CommitMessageService.test.ts
+++ b/src/lib/__tests__/CommitMessageService.test.ts
@@ -1,0 +1,36 @@
+import { CommitMessageService } from '../CommitMessageService';
+
+const dummyAI = () => ({ getResponseTextFromAI: jest.fn() });
+const dummyGit = (diff: string, files: string[]) => ({
+    getDiff: jest.fn().mockResolvedValue(diff),
+    listModifiedFiles: jest.fn().mockResolvedValue(files)
+});
+
+describe('CommitMessageService', () => {
+    test('uses single request when diff fits within maxTokens', async () => {
+        const ai = dummyAI();
+        (ai.getResponseTextFromAI as jest.Mock).mockResolvedValue('COMMIT: msg');
+        const git = dummyGit('diff', ['a.ts']);
+        const service = new CommitMessageService(ai as any, git as any, 100);
+        const msg = await service.generateCommitMessage('/p');
+        expect(msg).toBe('msg');
+        expect(ai.getResponseTextFromAI).toHaveBeenCalledTimes(1);
+        const call = (ai.getResponseTextFromAI as jest.Mock).mock.calls[0][0];
+        expect(call[0].content).toMatch('a.ts');
+        expect(call[0].content).toMatch('diff');
+    });
+
+    test('chunks diff when it exceeds maxTokens', async () => {
+        const ai = dummyAI();
+        (ai.getResponseTextFromAI as jest.Mock)
+            .mockResolvedValueOnce('CONTINUE')
+            .mockResolvedValueOnce('COMMIT: msg');
+        const largeDiff = 'line1\nline2\nline3\nline4\nline5';
+        const git = dummyGit(largeDiff, ['b.ts']);
+        // small token limit to force chunking
+        const service = new CommitMessageService(ai as any, git as any, 5);
+        const msg = await service.generateCommitMessage('/p');
+        expect(msg).toBe('msg');
+        expect(ai.getResponseTextFromAI as jest.Mock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/lib/consolidation/__tests__/CommitWorkflow.test.ts
+++ b/src/lib/consolidation/__tests__/CommitWorkflow.test.ts
@@ -1,5 +1,9 @@
 import { ConsolidationService } from '../ConsolidationService';
 
+// Chalk is ESM-only which Jest struggles to load in the CommonJS test environment
+// so we provide a simple manual mock that returns proxy functions.
+jest.mock('chalk', () => ({ __esModule: true, default: new Proxy({}, { get: () => (s: string) => s }) }));
+
 describe('commit workflow', () => {
   const baseConfig:any = { gemini:{}, project:{} };
   const fs:any = {};


### PR DESCRIPTION
## Summary
- enhance CommitMessageService to send a single request when diff is small
- include changed files in prompts for better context
- mock chalk in CommitWorkflow test to avoid ESM issues
- add tests for CommitMessageService

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f6c163dec833097fa65d603301bf1