### PR TITLE
Fix commitAll to exec without shell

### DIFF
--- a/src/lib/GitService.ts
+++ b/src/lib/GitService.ts
@@ -4,6 +4,10 @@ import path from 'path'; // Import path
 import ignore, { Ignore } from 'ignore'; // Import ignore
 import { CommandService } from './CommandService';
 import { FileSystem } from './FileSystem'; // <-- Import FileSystem
+import { execFile as execFileCb } from 'child_process';
+import { promisify } from 'util';
+
+const execFile = promisify(execFileCb);
 
 export class GitService {
     private commandService: CommandService;
@@ -136,8 +140,7 @@ export class GitService {
 
     /** Commits all staged changes with the provided message. */
     async commitAll(projectRoot: string, message: string): Promise<void> {
-        const escaped = message.replace(/"/g, '\\"');
-        await this.commandService.run(`git commit -m "${escaped}"`, { cwd: projectRoot });
+        await execFile('git', ['commit', '-m', message], { cwd: projectRoot });
     }
 
     // --- MOVED FROM FileSystem: ensureGitignoreRules ---

--- a/src/lib/__tests__/GitService.test.ts
+++ b/src/lib/__tests__/GitService.test.ts
@@ -1,6 +1,35 @@
 import { GitService } from '../GitService';
+import { execFile as execFileCb } from 'child_process';
 
-describe('GitService', () => {
-    it('should be created', () => {
-    });
+// Chalk is ESM-only which Jest struggles to load in the CommonJS test environment
+// so we provide a simple manual mock that returns proxy functions.
+jest.mock('chalk', () => ({ __esModule: true, default: new Proxy({}, { get: () => (s: string) => s }) }));
+
+jest.mock('child_process', () => {
+  const execFile = jest.fn((cmd: string, args: string[], opts: any, cb: (err: any, stdout?: string, stderr?: string) => void) => {
+    if (typeof opts === 'function') {
+      cb = opts as any;
+      opts = undefined;
+    }
+    cb(null, '', '');
+  });
+  return { execFile };
+});
+
+describe('GitService.commitAll', () => {
+  it('uses execFile with argument array', async () => {
+    const commandService: any = {};
+    const fs: any = {};
+    const git = new GitService(commandService, fs);
+    const execFile = (execFileCb as unknown as jest.Mock);
+
+    await git.commitAll('/repo', 'msg');
+
+    expect(execFile).toHaveBeenCalledTimes(1);
+    const call = execFile.mock.calls[0];
+    expect(call[0]).toBe('git');
+    expect(call[1]).toEqual(['commit', '-m', 'msg']);
+    expect(call[2]).toEqual({ cwd: '/repo' });
+    expect(typeof call[3]).toBe('function');
+  });
 });


### PR DESCRIPTION
## Summary
- run `git commit` with `execFile` to avoid shell interpolation
- add unit test ensuring `commitAll` uses `execFile`

## Testing
- `npm install`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_685f6e1ff514833082511e65724ddfd2