### PR TITLE
Start test coverage phase 2

### DIFF
--- a/src/lib/__tests__/ProjectContextBuilder.test.ts
+++ b/src/lib/__tests__/ProjectContextBuilder.test.ts
@@ -1,6 +1,43 @@
+import path from 'path';
 import { ProjectContextBuilder } from '../ProjectContextBuilder';
+import { ProjectAnalysisCache } from '../analysis/types';
 
-describe('ProjectContextBuilder', () => {
-    it('should be created', () => {
-    });
+describe('ProjectContextBuilder.buildContext (analysis_cache mode)', () => {
+  const fsMock = { readAnalysisCache: jest.fn() } as any;
+  const gitMock = {} as any;
+  const aiClient = {} as any;
+  const config: any = {
+    analysis: { cache_file_path: 'cache.json' },
+    context: { mode: 'analysis_cache' },
+    gemini: { max_prompt_tokens: 1000 },
+    project: {}
+  };
+  let builder: ProjectContextBuilder;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    builder = new ProjectContextBuilder(fsMock, gitMock, '/root', config, aiClient);
+  });
+
+  it('formats cache when present', async () => {
+    const cache: ProjectAnalysisCache = {
+      overallSummary: 'overall',
+      entries: [
+        { filePath: 'a.ts', type: 'text_analyze', size: 10, loc: 1, summary: 'sum', lastAnalyzed: 'now' }
+      ]
+    };
+    fsMock.readAnalysisCache.mockResolvedValue(cache);
+
+    const res = await builder.buildContext();
+
+    expect(fsMock.readAnalysisCache).toHaveBeenCalledWith(path.resolve('/root', 'cache.json'));
+    expect(res.context).toContain('Project Analysis Overview');
+    expect(res.context).toContain('a.ts');
+    expect(typeof res.tokenCount).toBe('number');
+  });
+
+  it('throws when cache missing', async () => {
+    fsMock.readAnalysisCache.mockResolvedValue(null);
+    await expect(builder.buildContext()).rejects.toThrow(/Analysis cache/);
+  });
 });

--- a/src/lib/__tests__/ProjectScaffolder.test.ts
+++ b/src/lib/__tests__/ProjectScaffolder.test.ts
@@ -1,6 +1,73 @@
-import { ProjectScaffolder } from '../ProjectScaffolder';
+import path from 'path';
+import { ProjectScaffolder, ScaffoldOptions } from '../ProjectScaffolder';
 
-describe('ProjectScaffolder', () => {
-    it('should be created', () => {
-    });
+describe('ProjectScaffolder.scaffoldProject', () => {
+  const fsMock = {
+    ensureDirExists: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined)
+  } as any;
+  const gitMock = {
+    initializeRepository: jest.fn().mockResolvedValue(undefined),
+    ensureGitignoreRules: jest.fn().mockResolvedValue(undefined)
+  } as any;
+  let scaffolder: ProjectScaffolder;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scaffolder = new ProjectScaffolder(fsMock, gitMock);
+  });
+
+  it('creates full Node/TypeScript project structure', async () => {
+    const opts: ScaffoldOptions = {
+      language: 'TypeScript',
+      framework: 'Node',
+      directoryName: 'proj'
+    };
+    const cwd = process.cwd();
+    const expectedPath = path.resolve(cwd, 'proj');
+
+    const result = await scaffolder.scaffoldProject(opts);
+
+    expect(result).toBe(expectedPath);
+    expect(fsMock.ensureDirExists).toHaveBeenCalledWith(expectedPath);
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      path.join(expectedPath, 'README.md'),
+      expect.stringContaining('# proj')
+    );
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      path.join(expectedPath, 'package.json'),
+      expect.stringContaining('"name": "proj"')
+    );
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      path.join(expectedPath, 'tsconfig.json'),
+      expect.any(String)
+    );
+    expect(fsMock.ensureDirExists).toHaveBeenCalledWith(path.join(expectedPath, 'src'));
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      path.join(expectedPath, 'src/index.ts'),
+      expect.stringContaining('Hello from Kai')
+    );
+    expect(gitMock.initializeRepository).toHaveBeenCalledWith(expectedPath);
+    expect(gitMock.ensureGitignoreRules).toHaveBeenCalledWith(expectedPath);
+  });
+
+  it('skips Node extras for other languages', async () => {
+    const opts: ScaffoldOptions = {
+      language: 'Python',
+      framework: 'Flask',
+      directoryName: 'pyproj'
+    };
+    const expectedPath = path.resolve(process.cwd(), 'pyproj');
+    await scaffolder.scaffoldProject(opts);
+
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      path.join(expectedPath, 'README.md'),
+      expect.any(String)
+    );
+    // package.json should not be created
+    expect(fsMock.writeFile).not.toHaveBeenCalledWith(
+      path.join(expectedPath, 'package.json'),
+      expect.any(String)
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- flesh out `ProjectScaffolder` tests
- add initial `ProjectContextBuilder` coverage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fcad005288330a948a145d3cdd95f