### PR TITLE
Start test coverage phase 2

### DIFF
--- a/src/lib/__tests__/ConversationManager.test.ts
+++ b/src/lib/__tests__/ConversationManager.test.ts
@@ -1,0 +1,71 @@
+import path from 'path';
+import Conversation from '../models/Conversation';
+import { ConversationManager } from '../ConversationManager';
+
+describe('ConversationManager private flows', () => {
+  const config = { chatsDir: '/tmp/chats', context: { mode: 'full' } } as any;
+  const fs = {} as any;
+  const aiClient = {} as any;
+  const ui = {} as any;
+  const builder = {} as any;
+  const consolidation = {} as any;
+  let manager: ConversationManager;
+
+  beforeEach(() => {
+    manager = new ConversationManager(config, fs, aiClient, ui, builder, consolidation);
+  });
+
+  describe('_processLoopIteration', () => {
+    it('handles /consolidate command', async () => {
+      const convo = new Conversation();
+      const spyCons = jest.spyOn<any, any>(manager as any, '_handleConsolidateCommand').mockResolvedValue(undefined);
+      const spyAI = jest.spyOn<any, any>(manager as any, '_callAIWithContext').mockResolvedValue(undefined);
+
+      await (manager as any)._processLoopIteration(convo, '/consolidate', '/c');
+
+      expect(spyCons).toHaveBeenCalledWith(convo, '/c');
+      expect(spyAI).not.toHaveBeenCalled();
+    });
+
+    it('handles regular prompt', async () => {
+      const convo = new Conversation();
+      const spyCons = jest.spyOn<any, any>(manager as any, '_handleConsolidateCommand').mockResolvedValue(undefined);
+      const spyAI = jest.spyOn<any, any>(manager as any, '_callAIWithContext').mockResolvedValue(undefined);
+
+      await (manager as any)._processLoopIteration(convo, 'hello', '/c');
+
+      expect(spyAI).toHaveBeenCalledWith(convo, 'hello', '/c');
+      expect(spyCons).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('runSession', () => {
+    it('loads conversation and runs loop', async () => {
+      const convo = new Conversation();
+      const load = jest.spyOn<any, any>(manager as any, '_loadOrCreateConversation').mockResolvedValue(convo);
+      const loop = jest.spyOn<any, any>(manager as any, '_handleUserInputLoop').mockResolvedValue(undefined);
+      const cleanup = jest.spyOn<any, any>(manager as any, '_cleanupEditorFile').mockResolvedValue(undefined);
+
+      await manager.runSession('Chat One', true);
+
+      const snake = 'chat_one';
+      const expectedPath = path.join(config.chatsDir, `${snake}.jsonl`);
+      expect(load).toHaveBeenCalledWith('Chat One', true, expectedPath);
+      expect(loop).toHaveBeenCalledWith('Chat One', convo, expect.objectContaining({ conversationFilePath: expectedPath }));
+      expect(cleanup).toHaveBeenCalled();
+    });
+
+    it('handles errors and calls error handler', async () => {
+      const err = new Error('boom');
+      jest.spyOn<any, any>(manager as any, '_loadOrCreateConversation').mockRejectedValue(err);
+      const handleErr = jest.spyOn<any, any>(manager as any, '_handleConversationError').mockResolvedValue(undefined);
+      const cleanup = jest.spyOn<any, any>(manager as any, '_cleanupEditorFile').mockResolvedValue(undefined);
+
+      await manager.runSession('Oops', false);
+
+      expect(handleErr).toHaveBeenCalledWith(err, 'Oops', expect.any(String));
+      expect(cleanup).toHaveBeenCalled();
+    });
+  });
+});
+

--- a/src/lib/__tests__/ProjectContextBuilder.test.ts
+++ b/src/lib/__tests__/ProjectContextBuilder.test.ts
@@ -1,6 +1,43 @@
+import path from 'path';
 import { ProjectContextBuilder } from '../ProjectContextBuilder';
+import { ProjectAnalysisCache } from '../analysis/types';
 
-describe('ProjectContextBuilder', () => {
-    it('should be created', () => {
-    });
+describe('ProjectContextBuilder.buildContext (analysis_cache mode)', () => {
+  const fsMock = { readAnalysisCache: jest.fn() } as any;
+  const gitMock = {} as any;
+  const aiClient = {} as any;
+  const config: any = {
+    analysis: { cache_file_path: 'cache.json' },
+    context: { mode: 'analysis_cache' },
+    gemini: { max_prompt_tokens: 1000 },
+    project: {}
+  };
+  let builder: ProjectContextBuilder;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    builder = new ProjectContextBuilder(fsMock, gitMock, '/root', config, aiClient);
+  });
+
+  it('formats cache when present', async () => {
+    const cache: ProjectAnalysisCache = {
+      overallSummary: 'overall',
+      entries: [
+        { filePath: 'a.ts', type: 'text_analyze', size: 10, loc: 1, summary: 'sum', lastAnalyzed: 'now' }
+      ]
+    };
+    fsMock.readAnalysisCache.mockResolvedValue(cache);
+
+    const res = await builder.buildContext();
+
+    expect(fsMock.readAnalysisCache).toHaveBeenCalledWith(path.resolve('/root', 'cache.json'));
+    expect(res.context).toContain('Project Analysis Overview');
+    expect(res.context).toContain('a.ts');
+    expect(typeof res.tokenCount).toBe('number');
+  });
+
+  it('throws when cache missing', async () => {
+    fsMock.readAnalysisCache.mockResolvedValue(null);
+    await expect(builder.buildContext()).rejects.toThrow(/Analysis cache/);
+  });
 });

--- a/src/lib/__tests__/ProjectScaffolder.test.ts
+++ b/src/lib/__tests__/ProjectScaffolder.test.ts
@@ -1,6 +1,73 @@
-import { ProjectScaffolder } from '../ProjectScaffolder';
+import path from 'path';
+import { ProjectScaffolder, ScaffoldOptions } from '../ProjectScaffolder';
 
-describe('ProjectScaffolder', () => {
-    it('should be created', () => {
-    });
+describe('ProjectScaffolder.scaffoldProject', () => {
+  const fsMock = {
+    ensureDirExists: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined)
+  } as any;
+  const gitMock = {
+    initializeRepository: jest.fn().mockResolvedValue(undefined),
+    ensureGitignoreRules: jest.fn().mockResolvedValue(undefined)
+  } as any;
+  let scaffolder: ProjectScaffolder;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scaffolder = new ProjectScaffolder(fsMock, gitMock);
+  });
+
+  it('creates full Node/TypeScript project structure', async () => {
+    const opts: ScaffoldOptions = {
+      language: 'TypeScript',
+      framework: 'Node',
+      directoryName: 'proj'
+    };
+    const cwd = process.cwd();
+    const expectedPath = path.resolve(cwd, 'proj');
+
+    const result = await scaffolder.scaffoldProject(opts);
+
+    expect(result).toBe(expectedPath);
+    expect(fsMock.ensureDirExists).toHaveBeenCalledWith(expectedPath);
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      path.join(expectedPath, 'README.md'),
+      expect.stringContaining('# proj')
+    );
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      path.join(expectedPath, 'package.json'),
+      expect.stringContaining('"name": "proj"')
+    );
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      path.join(expectedPath, 'tsconfig.json'),
+      expect.any(String)
+    );
+    expect(fsMock.ensureDirExists).toHaveBeenCalledWith(path.join(expectedPath, 'src'));
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      path.join(expectedPath, 'src/index.ts'),
+      expect.stringContaining('Hello from Kai')
+    );
+    expect(gitMock.initializeRepository).toHaveBeenCalledWith(expectedPath);
+    expect(gitMock.ensureGitignoreRules).toHaveBeenCalledWith(expectedPath);
+  });
+
+  it('skips Node extras for other languages', async () => {
+    const opts: ScaffoldOptions = {
+      language: 'Python',
+      framework: 'Flask',
+      directoryName: 'pyproj'
+    };
+    const expectedPath = path.resolve(process.cwd(), 'pyproj');
+    await scaffolder.scaffoldProject(opts);
+
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      path.join(expectedPath, 'README.md'),
+      expect.any(String)
+    );
+    // package.json should not be created
+    expect(fsMock.writeFile).not.toHaveBeenCalledWith(
+      path.join(expectedPath, 'package.json'),
+      expect.any(String)
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- flesh out `ProjectScaffolder` tests
- add initial `ProjectContextBuilder` coverage
- cover `ConversationManager` flows

## Testing
- `npx jest --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fcad005288330a948a145d3cdd95f