### PR TITLE
Fix tests and mocks for Phase 2

### DIFF
--- a/__mocks__/chalk.js
+++ b/__mocks__/chalk.js
@@ -9,4 +9,6 @@ module.exports = {
   green: (s) => s,
   blue: (s) => s,
   cyan: (s) => s,
+  magenta: (s) => s,
+  gray: (s) => s,
 };


### PR DESCRIPTION
## Summary
- extend chalk mock with gray and magenta
- reset conversation per test in `AIClient` tests and adjust error expectations
- provide explicit config object in `CodeProcessor` tests
- fix expectations for consolidation path conversions
- ensure mocked generateContent returns value for flash model

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fea5ea1e48330a5b3ee3b37e0a18c