### PR TITLE
Expand ConversationManager and ProjectContextBuilder tests

### DIFF
--- a/src/lib/__tests__/ProjectContextBuilder.test.ts
+++ b/src/lib/__tests__/ProjectContextBuilder.test.ts
@@ -80,3 +80,93 @@ describe('ProjectContextBuilder utilities', () => {
     expect(res).toBe('a\n\n b');
   });
 });
+
+describe('ProjectContextBuilder.buildContext other modes', () => {
+  const fsMock: any = {
+    readAnalysisCache: jest.fn(),
+    getProjectFiles: jest.fn(),
+    readFileContents: jest.fn(),
+  };
+  const gitMock: any = { getIgnoreRules: jest.fn() };
+  const aiClient: any = { getResponseTextFromAI: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds full context', async () => {
+    const config: any = {
+      analysis: { cache_file_path: 'cache.json' },
+      context: { mode: 'full' },
+      gemini: { max_prompt_tokens: 1000 },
+      project: {},
+    };
+    fsMock.getProjectFiles.mockResolvedValue(['/root/a.ts']);
+    fsMock.readFileContents.mockResolvedValue({ '/root/a.ts': 'code' });
+    gitMock.getIgnoreRules.mockResolvedValue({ ignores: () => false });
+
+    const builder = new ProjectContextBuilder(fsMock, gitMock, '/root', config, aiClient);
+    const res = await builder.buildContext();
+
+    expect(fsMock.getProjectFiles).toHaveBeenCalled();
+    expect(res.context).toContain('File: a.ts');
+  });
+
+  it('warns when dynamic cache missing', async () => {
+    const config: any = {
+      analysis: { cache_file_path: 'cache.json' },
+      context: { mode: 'dynamic' },
+      gemini: { max_prompt_tokens: 1000 },
+      project: {},
+    };
+    fsMock.readAnalysisCache.mockResolvedValue(null);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const builder = new ProjectContextBuilder(fsMock, gitMock, '/root', config, aiClient);
+    const res = await builder.buildContext('q', 'h');
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(res.context).toContain('missing or empty');
+  });
+
+  it('builds dynamic context with selected files', async () => {
+    const config: any = {
+      analysis: { cache_file_path: 'cache.json' },
+      context: { mode: 'dynamic' },
+      gemini: { max_prompt_tokens: 1000 },
+      project: {},
+    };
+    const cache: ProjectAnalysisCache = { overallSummary: '', entries: [{ filePath: 'a.ts', type: 'text_analyze', size: 10, loc: 1, summary: 's', lastAnalyzed: 'now' }] };
+    fsMock.readAnalysisCache.mockResolvedValue(cache);
+    aiClient.getResponseTextFromAI.mockResolvedValue('a.ts');
+    fsMock.readFile = jest.fn().mockResolvedValue('code');
+
+    const builder = new ProjectContextBuilder(fsMock, gitMock, '/root', config, aiClient);
+    const res = await builder.buildContext('q', 'h');
+
+    expect(aiClient.getResponseTextFromAI).toHaveBeenCalled();
+    expect(fsMock.readFile).toHaveBeenCalledWith('/root/a.ts');
+    expect(res.context).toContain('File: a.ts');
+  });
+
+  it('falls back when relevance check fails', async () => {
+    const config: any = {
+      analysis: { cache_file_path: 'cache.json' },
+      context: { mode: 'dynamic' },
+      gemini: { max_prompt_tokens: 1000 },
+      project: {},
+    };
+    const cache: ProjectAnalysisCache = {
+      overallSummary: 'o',
+      entries: [{ filePath: 'a.ts', type: 'text_analyze', size: 10, loc: 1, summary: 's', lastAnalyzed: 'now' }]
+    };
+    fsMock.readAnalysisCache.mockResolvedValue(cache);
+    aiClient.getResponseTextFromAI.mockRejectedValue(new Error('bad'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const builder = new ProjectContextBuilder(fsMock, gitMock, '/root', config, aiClient);
+    const res = await builder.buildContext('q', 'h');
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(res.context).toContain('Project Analysis Overview');
+  });
+});


### PR DESCRIPTION
## Summary
- add failure case coverage for ConversationManager cleanup & consolidation
- exercise ProjectContextBuilder in full and dynamic modes
- test dynamic relevance failure and success paths

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686014469cc4833098b87356abb99cf9