### PR TITLE
Add Jest harden feature

### DIFF
--- a/src/kai.ts
+++ b/src/kai.ts
@@ -12,7 +12,8 @@ import {
     UserInterface,
     UserInteractionResult,
     ChangeModeInteractionResult,
-    ScaffoldProjectInteractionResult
+    ScaffoldProjectInteractionResult,
+    HardenInteractionResult
 } from './lib/UserInterface';
 // REMOVED: KanbanData, KanbanColumn, KanbanCard imports
 import { CodeProcessor } from './lib/CodeProcessor';
@@ -352,6 +353,12 @@ async function main() {
                 await codeProcessor.processConsolidationRequest(targetIdentifier);
                 // --- End call ---
                 console.log(chalk.magenta(`🏁 Consolidation process finished for ${chalk.cyan(targetIdentifier)}.`));
+
+            } else if (mode === 'Harden') {
+                 if (!codeProcessor) throw new Error("CodeProcessor not initialized.");
+                 const hardenResult = interactionResult as HardenInteractionResult;
+                 await codeProcessor.processHardeningRequest(hardenResult.tool);
+                 console.log(chalk.magenta('🏁 Hardening process completed.'));
 
             } else if (mode === 'Delete Conversation...') {
                 if (!config) throw new Error("Config not initialized."); // Guard

--- a/src/lib/CodeProcessor.ts
+++ b/src/lib/CodeProcessor.ts
@@ -14,6 +14,7 @@ import { ConversationManager } from './ConversationManager'; // <-- ADDED Import
 import { toSnakeCase } from './utils'; // <-- Added for path generation duplication
 import { TypeScriptLoop } from './consolidation/feedback/TypeScriptLoop';
 import { CommitMessageService } from './CommitMessageService';
+import { TestCoverageRaiser } from './hardening/TestCoverageRaiser';
 
 const CONSOLIDATION_SUCCESS_MARKER = "[System: Consolidation Completed Successfully]";
 
@@ -29,6 +30,7 @@ class CodeProcessor {
     gitService: GitService;
     conversationManager: ConversationManager; // <-- ADDED Property
     commitMessageService: CommitMessageService;
+    hardenService: TestCoverageRaiser;
 
     // --- MODIFIED Constructor ---
     constructor(
@@ -78,6 +80,14 @@ class CodeProcessor {
             this.ui, // Pass injected UI
             this.contextBuilder, // Pass injected ContextBuilder
             this.consolidationService // Pass the created ConsolidationService
+        );
+
+        this.hardenService = new TestCoverageRaiser(
+            this.config,
+            this.fs,
+            this.commandService,
+            this.aiClient,
+            this.projectRoot
         );
     }
     // --- END MODIFIED Constructor ---
@@ -162,6 +172,10 @@ class CodeProcessor {
         }
     }
 
+    async processHardeningRequest(tool: string): Promise<void> {
+        await this.hardenService.process(tool);
+    }
+
     /**
      * Updates the AI client across the processor and dependent services.
      */
@@ -169,6 +183,7 @@ class CodeProcessor {
         this.aiClient = aiClient;
         this.conversationManager.updateAIClient(aiClient);
         this.consolidationService.updateAIClient(aiClient);
+        this.hardenService.updateAIClient(aiClient);
     }
 
     /** Returns conversation messages since the last successful consolidation. */

--- a/src/lib/hardening/TestCoveragePrompts.ts
+++ b/src/lib/hardening/TestCoveragePrompts.ts
@@ -1,0 +1,7 @@
+export const TestCoveragePrompts = {
+    generateTests: (
+        filePath: string,
+        fileContent: string,
+        coverageInfo: string
+    ): string => `You are an AI software engineer tasked with improving test coverage.\nFile: ${filePath}\nCurrent coverage info: ${coverageInfo}\nFile content:\n\`\`\`\n${fileContent}\n\`\`\`\nGenerate Jest tests to maximize coverage. Respond only with the test file content.`
+};

--- a/src/lib/hardening/TestCoverageRaiser.ts
+++ b/src/lib/hardening/TestCoverageRaiser.ts
@@ -1,0 +1,106 @@
+import path from 'path';
+import chalk from 'chalk';
+import { Config } from '../Config';
+import { FileSystem } from '../FileSystem';
+import { CommandService } from '../CommandService';
+import { AIClient } from '../AIClient';
+import { TestCoveragePrompts } from './TestCoveragePrompts';
+
+export class TestCoverageRaiser {
+    private config: Config;
+    private fs: FileSystem;
+    private commandService: CommandService;
+    private aiClient: AIClient;
+    private projectRoot: string;
+
+    constructor(
+        config: Config,
+        fs: FileSystem,
+        commandService: CommandService,
+        aiClient: AIClient,
+        projectRoot: string
+    ) {
+        this.config = config;
+        this.fs = fs;
+        this.commandService = commandService;
+        this.aiClient = aiClient;
+        this.projectRoot = projectRoot;
+    }
+
+    updateAIClient(aiClient: AIClient) {
+        this.aiClient = aiClient;
+    }
+
+    async process(tool: string): Promise<void> {
+        if (tool !== 'jest') {
+            console.log(chalk.yellow(`Unsupported test framework: ${tool}`));
+            return;
+        }
+
+        await this._runJestCoverage();
+        const summaryPath = path.join(this.projectRoot, 'coverage', 'coverage-summary.json');
+        const summary = await this._readCoverageSummary(summaryPath);
+        if (!summary) {
+            console.log(chalk.red('Coverage summary not found.'));
+            return;
+        }
+
+        const targetFile = this._findLowestCoverageFile(summary);
+        if (!targetFile) {
+            console.log(chalk.green('All files fully covered.'));
+            return;
+        }
+        console.log(chalk.cyan(`Generating tests for ${targetFile}...`));
+        const fileContent = await this.fs.readFile(targetFile);
+        if (!fileContent) {
+            console.log(chalk.red(`Unable to read ${targetFile}`));
+            return;
+        }
+        const coverageInfo = JSON.stringify(summary[targetFile] || {});
+        const prompt = TestCoveragePrompts.generateTests(targetFile, fileContent, coverageInfo);
+        const testContent = await this.aiClient.getResponseTextFromAI([
+            { role: 'user', content: prompt }
+        ], false);
+        const testPath = this._deriveTestPath(targetFile);
+        await this.fs.writeFile(testPath, testContent);
+        console.log(chalk.green(`Test written to ${testPath}`));
+    }
+
+    private _deriveTestPath(file: string): string {
+        const dir = path.dirname(file);
+        const base = path.basename(file).replace(/\.ts$/, '.test.ts');
+        return path.join(dir, base);
+    }
+
+    private async _runJestCoverage(): Promise<void> {
+        try {
+            await this.commandService.run('npx jest --coverage --coverageReporters=json-summary', {
+                cwd: this.projectRoot
+            });
+        } catch (err) {
+            console.error(chalk.red('Jest coverage run failed.'), err);
+        }
+    }
+
+    private async _readCoverageSummary(p: string): Promise<any | null> {
+        try {
+            const raw = await this.fs.readFile(p);
+            if (!raw) return null;
+            return JSON.parse(raw);
+        } catch {
+            return null;
+        }
+    }
+
+    private _findLowestCoverageFile(summary: any): string | null {
+        let lowest: { path: string; pct: number } | null = null;
+        for (const [filePath, info] of Object.entries<any>(summary)) {
+            if (filePath === 'total') continue;
+            const pct = info.lines?.pct ?? 100;
+            if (lowest === null || pct < lowest.pct) {
+                lowest = { path: filePath, pct };
+            }
+        }
+        return lowest ? path.join(this.projectRoot, lowest.path) : null;
+    }
+}


### PR DESCRIPTION
## Summary
- implement test coverage raising service and prompts
- detect Jest & add `Harden` option in CLI
- wire up hardening service in `CodeProcessor`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860190c28a08330bdf18c59cd333b00