### PR TITLE
Derive project root via Git

### DIFF
--- a/src/kai.ts
+++ b/src/kai.ts
@@ -274,7 +274,7 @@ async function main() {
         // --- End Kanban Web Service ---
 
         // --- Instantiate CodeProcessor once before the loop ---
-        codeProcessor = new CodeProcessor(
+        codeProcessor = await CodeProcessor.create(
             config, // Pass the final config
             fs,
             commandService,

--- a/src/lib/CodeProcessor.ts
+++ b/src/lib/CodeProcessor.ts
@@ -30,14 +30,35 @@ class CodeProcessor {
     conversationManager: ConversationManager; // <-- ADDED Property
     commitMessageService: CommitMessageService;
 
-    // --- MODIFIED Constructor ---
-    constructor(
+    static async create(
         config: Config,
         fs: FileSystem,
         commandService: CommandService,
         gitService: GitService,
-        ui: UserInterface,                // <-- ADDED Parameter
-        contextBuilder: ProjectContextBuilder // <-- ADDED Parameter
+        ui: UserInterface,
+        contextBuilder: ProjectContextBuilder
+    ): Promise<CodeProcessor> {
+        const projectRoot = await gitService.getRepositoryRoot(process.cwd());
+        return new CodeProcessor(
+            config,
+            fs,
+            commandService,
+            gitService,
+            ui,
+            contextBuilder,
+            projectRoot
+        );
+    }
+
+    // --- MODIFIED Constructor ---
+    private constructor(
+        config: Config,
+        fs: FileSystem,
+        commandService: CommandService,
+        gitService: GitService,
+        ui: UserInterface,
+        contextBuilder: ProjectContextBuilder,
+        projectRoot: string
     ) {
         this.config = config;
         this.fs = fs;
@@ -46,7 +67,7 @@ class CodeProcessor {
         this.ui = ui; // <-- Assign injected instance
         this.contextBuilder = contextBuilder; // <-- Assign injected instance
         this.aiClient = new AIClient(config); // AIClient only needs config (and fs internally)
-        this.projectRoot = process.cwd(); // projectRoot derived here
+        this.projectRoot = projectRoot;
 
         this.commitMessageService = new CommitMessageService(
             this.aiClient,

--- a/src/lib/GitService.ts
+++ b/src/lib/GitService.ts
@@ -19,6 +19,20 @@ export class GitService {
         this.fs = fileSystem; // <-- Assign injected FileSystem
     }
 
+    /**
+     * Returns the root directory of the current Git repository.
+     * Falls back to the provided cwd if the command fails.
+     */
+    async getRepositoryRoot(cwd: string): Promise<string> {
+        try {
+            const { stdout } = await this.commandService.run('git rev-parse --show-toplevel', { cwd });
+            return stdout.trim();
+        } catch (err) {
+            console.warn(chalk.yellow('Could not determine git repository root, defaulting to current directory.'));
+            return cwd;
+        }
+    }
+
     // --- isGitRepository, initializeRepository (remain unchanged) ---
     async isGitRepository(projectRoot: string): Promise<boolean> {
         console.log(chalk.dim("  Checking if project is a Git repository..."));

--- a/src/lib/__tests__/CodeProcessor.test.ts
+++ b/src/lib/__tests__/CodeProcessor.test.ts
@@ -43,7 +43,7 @@ describe('CodeProcessor', () => {
 
     let codeProcessor: CodeProcessor;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
 
         // Instantiate mocks
@@ -83,7 +83,9 @@ describe('CodeProcessor', () => {
         (ConsolidationService as jest.Mock).mockImplementation(() => mockConsolidationService);
         (ConversationManager as jest.Mock).mockImplementation(() => mockConversationManager);
 
-        codeProcessor = new CodeProcessor(
+        mockGitService.getRepositoryRoot = jest.fn().mockResolvedValue('/repo');
+
+        codeProcessor = await CodeProcessor.create(
             mockConfig,
             mockFs,
             mockCommandService,
@@ -108,7 +110,8 @@ describe('CodeProcessor', () => {
 
         expect(AIClient).toHaveBeenCalledWith(mockConfig);
         expect(CommitMessageService).toHaveBeenCalledWith(mockAIClient, mockGitService, mockConfig.gemini.max_prompt_tokens);
-        expect(ConsolidationService).toHaveBeenCalledWith(mockConfig, mockFs, mockAIClient, process.cwd(), mockGitService, mockUi, mockCommitMessageService, expect.any(Array));
+        expect(ConsolidationService).toHaveBeenCalledWith(mockConfig, mockFs, mockAIClient, '/repo', mockGitService, mockUi, mockCommitMessageService, expect.any(Array));
+        expect(mockGitService.getRepositoryRoot).toHaveBeenCalledWith(process.cwd());
         expect(ConversationManager).toHaveBeenCalledWith(mockConfig, mockFs, mockAIClient, mockUi, mockContextBuilder, mockConsolidationService);
     });
 


### PR DESCRIPTION
## Summary
- add `getRepositoryRoot` to GitService for retrieving the repo root
- create `CodeProcessor.create` to resolve repository root before instantiation
- use the new async factory in `kai.ts`
- update CodeProcessor unit tests for the repository root lookup

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68601d4a4c9483309c9974c5a3099091