### PR TITLE
Add coverage iteration config and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Key settings include:
 *   `gemini.interactive_prompt_review`: Set to `true` to review/edit prompts in Sublime Text before sending to Gemini Pro models during chat.
 *   `project.typescript_autofix`: If `true`, run `tsc --noEmit` after each consolidation pass.
 *   `project.autofix_iterations`: How many times Kai will attempt to re-run generation after compilation errors (default 3).
+*   `project.coverage_iterations`: Maximum loops to generate tests and rerun coverage reports (default 3).
 
 *(Refer to the `src/lib/config_defaults.ts` file for default values).*
 

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,9 @@ project:
   prompts_dir: "prompts"
   prompt_template: "prompt_template.yaml"
   chats_dir: ".kai/logs" # Default location for conversation logs
+  typescript_autofix: false
+  autofix_iterations: 3
+  coverage_iterations: 3
 
 gemini:
   model_name: "gemini-2.5-flash" # Default primary model (Flash)

--- a/src/lib/Config.ts
+++ b/src/lib/Config.ts
@@ -33,6 +33,7 @@ interface ProjectConfig {
     chats_dir?: string; // Directory for conversation logs
     typescript_autofix?: boolean;
     autofix_iterations?: number;
+    coverage_iterations?: number;
 }
 
 // *** ADDED: Analysis Config Interface ***
@@ -148,6 +149,7 @@ class ConfigLoader /* implements IConfig */ { // Let TS infer implementation det
             chats_dir: yamlConfig.project?.chats_dir || ".kai/logs", // Using the updated default
             typescript_autofix: yamlConfig.project?.typescript_autofix ?? false,
             autofix_iterations: yamlConfig.project?.autofix_iterations ?? 3,
+            coverage_iterations: yamlConfig.project?.coverage_iterations ?? 3,
         };
 
         // *** ADDED: Default and Loading for Analysis Config ***
@@ -195,6 +197,7 @@ class ConfigLoader /* implements IConfig */ { // Let TS infer implementation det
                 chats_dir: this.project.chats_dir, // Save the relative path
                 typescript_autofix: this.project.typescript_autofix,
                 autofix_iterations: this.project.autofix_iterations,
+                coverage_iterations: this.project.coverage_iterations,
             },
             analysis: {
                 cache_file_path: this.analysis.cache_file_path,

--- a/src/lib/config_defaults.ts
+++ b/src/lib/config_defaults.ts
@@ -13,6 +13,7 @@ project:
   chats_dir: ".kai/logs" # Directory for conversation logs (inside .kai)
   typescript_autofix: false # Run tsc after each consolidation
   autofix_iterations: 3 # Max compile/apply iterations
+  coverage_iterations: 3 # Max test coverage improvement iterations
 
 # --- Analysis & Context Caching (Optional) ---
 # analysis:

--- a/src/lib/test/CoverageService.ts
+++ b/src/lib/test/CoverageService.ts
@@ -1,0 +1,34 @@
+import { Config } from '../Config';
+import { TestRunnerService } from './TestRunnerService';
+
+export interface TestGenerator {
+    generateTests(summary: any): Promise<void>;
+}
+
+export class CoverageService {
+    private config: Config;
+    private runner: TestRunnerService;
+    private generator: TestGenerator;
+
+    constructor(config: Config, runner: TestRunnerService, generator: TestGenerator) {
+        this.config = config;
+        this.runner = runner;
+        this.generator = generator;
+    }
+
+    private hasUncovered(summary: any): boolean {
+        return summary.total && summary.total.lines && summary.total.lines.pct < 100;
+    }
+
+    async improveCoverage(projectRoot: string): Promise<any> {
+        const maxIter = this.config.project.coverage_iterations ?? 3;
+        let iter = 0;
+        let summary = await this.runner.runCoverage(projectRoot);
+        while (this.hasUncovered(summary) && iter < maxIter) {
+            await this.generator.generateTests(summary);
+            summary = await this.runner.runCoverage(projectRoot);
+            iter++;
+        }
+        return summary;
+    }
+}

--- a/src/lib/test/TestRunnerService.ts
+++ b/src/lib/test/TestRunnerService.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+import { CommandService } from '../CommandService';
+import { FileSystem } from '../FileSystem';
+
+/**
+ * Runs Jest with coverage and returns the parsed coverage summary.
+ */
+export class TestRunnerService {
+    private command: CommandService;
+    private fs: FileSystem;
+
+    constructor(command: CommandService, fs: FileSystem) {
+        this.command = command;
+        this.fs = fs;
+    }
+
+    async runCoverage(projectRoot: string): Promise<any> {
+        await this.command.run('npx jest --coverage --coverageReporters=json-summary', { cwd: projectRoot });
+        const summaryPath = path.join(projectRoot, 'coverage', 'coverage-summary.json');
+        const content = await this.fs.readFile(summaryPath);
+        if (!content) throw new Error('Coverage summary not found');
+        return JSON.parse(content);
+    }
+}

--- a/src/lib/test/__tests__/CoverageService.test.ts
+++ b/src/lib/test/__tests__/CoverageService.test.ts
@@ -1,0 +1,18 @@
+import { CoverageService, TestGenerator } from '../CoverageService';
+
+describe('CoverageService', () => {
+  it('loops until coverage is 100%', async () => {
+    const config: any = { project: { coverage_iterations: 2 } };
+    const runner = { runCoverage: jest.fn()
+      .mockResolvedValueOnce({ total: { lines: { pct: 80 } } })
+      .mockResolvedValueOnce({ total: { lines: { pct: 90 } } })
+      .mockResolvedValueOnce({ total: { lines: { pct: 100 } } })
+    } as any;
+    const generator: TestGenerator = { generateTests: jest.fn().mockResolvedValue(undefined) };
+    const svc = new CoverageService(config, runner, generator);
+    const summary = await svc.improveCoverage('/p');
+    expect(runner.runCoverage).toHaveBeenCalledTimes(3);
+    expect(generator.generateTests).toHaveBeenCalledTimes(2);
+    expect(summary.total.lines.pct).toBe(100);
+  });
+});

--- a/src/lib/test/__tests__/TestRunnerService.test.ts
+++ b/src/lib/test/__tests__/TestRunnerService.test.ts
@@ -1,0 +1,12 @@
+import { TestRunnerService } from '../TestRunnerService';
+
+describe('TestRunnerService', () => {
+  it('runs jest and parses summary', async () => {
+    const cmd = { run: jest.fn().mockResolvedValue({ stdout: '', stderr: '' }) } as any;
+    const fs = { readFile: jest.fn().mockResolvedValue('{"total":{"lines":{"pct":80}}}') } as any;
+    const svc = new TestRunnerService(cmd, fs);
+    const summary = await svc.runCoverage('/p');
+    expect(cmd.run).toHaveBeenCalledWith('npx jest --coverage --coverageReporters=json-summary', { cwd: '/p' });
+    expect(summary.total.lines.pct).toBe(80);
+  });
+});


### PR DESCRIPTION
## Summary
- expose `project.coverage_iterations` in config
- implement `TestRunnerService` to run Jest with coverage
- implement `CoverageService` to loop test generation up to a configured limit
- document the new setting
- add unit tests for the new services

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68602c6ff0fc8330b9e7b7d7e4bebde1