### PR TITLE
Add placeholders for hardening test coverage

### DIFF
--- a/src/lib/hardening/__tests__/TestCoveragePrompts.test.ts
+++ b/src/lib/hardening/__tests__/TestCoveragePrompts.test.ts
@@ -1,0 +1,2 @@
+import { TestCoveragePrompts } from '../TestCoveragePrompts';
+describe('TestCoveragePrompts', () => {});

--- a/src/lib/hardening/__tests__/TestCoverageRaiser.test.ts
+++ b/src/lib/hardening/__tests__/TestCoverageRaiser.test.ts
@@ -1,0 +1,2 @@
+import { TestCoverageRaiser } from '../TestCoverageRaiser';
+describe('TestCoverageRaiser', () => {});


### PR DESCRIPTION
## Summary
- add placeholder tests for TestCoverageRaiser
- add placeholder tests for TestCoveragePrompts

## Testing
- `npm test` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_6860f6bd85148330aa82a6f33cc3a0c2