### PR TITLE
Add hardening workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ Key settings include:
 
 When the TypeScript feedback loop is enabled, Kai runs `npx tsc --noEmit` after applying generated changes. Any compiler errors are appended to the conversation and the generation step is retried. The process repeats up to `project.autofix_iterations` times.
 
+### Hardening Workflow
+
+Kai can also raise your test coverage automatically. The `TestCoverageRaiser` utility runs your Jest suite with coverage enabled, identifies the file with the lowest coverage, and asks the AI to write a new test for it. Launch it by running `kai` and choosing **Harden** from the main menu (select the desired test framework). Kai will iterate up to `project.coverage_iterations` times, re-running coverage and generating tests until coverage improves. See [docs/100coverageplay.md](docs/100coverageplay.md) for a phased approach to reaching 100%.
+
 ## Development
 
 *   **Build:** `npm run build` (Compiles TypeScript from `src/` to `bin/`)

--- a/docs/100coverageplay.md
+++ b/docs/100coverageplay.md
@@ -2,6 +2,8 @@
 
 This plan outlines a phased approach to increase test coverage, focusing on critical modules first. Each phase identifies specific modules and testing priorities. You don't need to tackle everything at once; complete Phase 1, then move on to subsequent phases.
 
+For details on Kai's automated hardening command, see the [Hardening Workflow](../README.md#hardening-workflow) section in the README.
+
 -----
 
 ## 📊 Phase 1 — Foundation & I/O Primitives


### PR DESCRIPTION
## Summary
- document the hardening workflow and how to invoke it
- link to the coverage playbook

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686106b98ab883308bb7e50650531fa7