### PR TITLE
Improve test coverage automation

### DIFF
--- a/src/lib/hardening/TestCoveragePrompts.ts
+++ b/src/lib/hardening/TestCoveragePrompts.ts
@@ -3,5 +3,12 @@ export const TestCoveragePrompts = {
         filePath: string,
         fileContent: string,
         coverageInfo: string
-    ): string => `You are an AI software engineer tasked with improving test coverage.\nFile: ${filePath}\nCurrent coverage info: ${coverageInfo}\nFile content:\n\`\`\`\n${fileContent}\n\`\`\`\nGenerate Jest tests to maximize coverage. Respond only with the test file content.`
+    ): string => `You are an AI software engineer tasked with improving test coverage.\nFile: ${filePath}\nCurrent coverage info: ${coverageInfo}\nFile content:\n\`\`\`\n${fileContent}\n\`\`\`\nGenerate Jest tests to maximize coverage. Respond only with the test file content.`,
+
+    generateTestDiff: (
+        testPath: string,
+        testContent: string,
+        coverageInfo: string
+    ): string =>
+        `You are an AI software engineer tasked with improving test coverage.\nCurrent coverage info: ${coverageInfo}\nExisting test file ${testPath}:\n\`\`\`\n${testContent}\n\`\`\`\nProvide a unified diff patch for ${testPath} that adds one or more Jest tests to increase coverage. Respond only with the diff.`
 };

--- a/src/lib/hardening/__tests__/TestCoveragePrompts.test.ts
+++ b/src/lib/hardening/__tests__/TestCoveragePrompts.test.ts
@@ -5,4 +5,10 @@ describe('TestCoveragePrompts', () => {
         const result = TestCoveragePrompts.generateTests('file.ts', 'code', 'info');
         expect(result).toContain('file.ts');
     });
+
+    it('generates diff prompt', () => {
+        const diffPrompt = TestCoveragePrompts.generateTestDiff('file.test.ts', 'tests', 'cov');
+        expect(diffPrompt).toContain('file.test.ts');
+        expect(diffPrompt).toContain('cov');
+    });
 });

--- a/src/lib/hardening/__tests__/TestCoverageRaiser.test.ts
+++ b/src/lib/hardening/__tests__/TestCoverageRaiser.test.ts
@@ -1,10 +1,52 @@
 import { TestCoverageRaiser } from '../TestCoverageRaiser';
 import { FileSystem } from '../../FileSystem';
 import { CommandService } from '../../CommandService';
+import { AIClient } from '../../AIClient';
+import * as diff from 'diff';
 
 describe('TestCoverageRaiser', () => {
     it('creates instance', () => {
         const raiser = new TestCoverageRaiser({} as any, new FileSystem(), new CommandService(), {} as any, '/project');
         expect(raiser).toBeDefined();
+    });
+
+    it('improves coverage iteratively', async () => {
+        const config: any = { project: { coverage_iterations: 2 } };
+        let testContent: string | null = null;
+        let coverageReadCount = 0;
+        const summaries = [
+            { '/project/src/a.ts': { lines: { pct: 80 } }, total: {} },
+            { '/project/src/a.ts': { lines: { pct: 100 } }, total: {} }
+        ];
+
+        const fsMock = {
+            readFile: jest.fn(async (p: string) => {
+                if (p === '/project/coverage/coverage-summary.json') {
+                    return JSON.stringify(summaries[coverageReadCount++]);
+                }
+                if (p === '/project/src/a.test.ts') return testContent;
+                if (p === '/project/src/a.ts') return 'src';
+                return null;
+            }),
+            writeFile: jest.fn(async (p: string, c: string) => {
+                if (p === '/project/src/a.test.ts') testContent = c;
+            }),
+            applyDiffToFile: jest.fn(async () => {
+                testContent = 'patched';
+                return true;
+            })
+        } as unknown as FileSystem;
+
+        const cmd = { run: jest.fn().mockResolvedValue({ stdout: '', stderr: '' }) } as any as CommandService;
+
+        const patch = diff.createTwoFilesPatch('a.test.ts', 'a.test.ts', 'describe(\'a\', () => {});', 'describe(\'a\', () => {test(\'x\', () => {});});');
+        const ai = { getResponseTextFromAI: jest.fn().mockResolvedValue(patch) } as any as AIClient;
+
+        const raiser = new TestCoverageRaiser(config, fsMock, cmd, ai, '/project');
+        await raiser.process('jest');
+
+        expect(fsMock.writeFile).toHaveBeenCalledWith('/project/src/a.test.ts', expect.any(String));
+        expect(fsMock.applyDiffToFile).toHaveBeenCalledWith('/project/src/a.test.ts', patch);
+        expect(ai.getResponseTextFromAI).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
- add `generateTestDiff` to generate unified diff patches for test files
- extend `TestCoverageRaiser` to iteratively patch tests until coverage reaches 100%
- create Jest tests for the new prompt and coverage workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686112f315148330af62e8776322f711