### PR TITLE
Add fuzzy patching fallback

### DIFF
--- a/src/lib/__tests__/FileSystem.test.ts
+++ b/src/lib/__tests__/FileSystem.test.ts
@@ -131,6 +131,15 @@ describe('FileSystem', () => {
       expect(fs.readFileSync(filePath, 'utf8')).toBe('b\n');
     });
 
+    it('fuzzily applies patch when whitespace differs', async () => {
+      const filePath = path.join(tempDir, 'fuzzy.txt');
+      fs.writeFileSync(filePath, '  hello  \n');
+      const diff = require('diff').createTwoFilesPatch('fuzzy.txt', 'fuzzy.txt', 'hello\n', 'hi\n');
+      const result = await fsUtil.applyDiffToFile(filePath, diff);
+      expect(result).toBe(true);
+      expect(fs.readFileSync(filePath, 'utf8')).toBe('hi\n');
+    });
+
     it('returns false when patch fails', async () => {
       const cwd = process.cwd();
       process.chdir(tempDir);


### PR DESCRIPTION
## Summary
- extend FileSystem.applyDiffToFile with fuzzy patch application
- implement fuzzyApplyPatch helper
- test fuzzy diff application when whitespace differs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68611ad2043083308dd76894adf41b80