### PR TITLE
log diff failures into conversation

### DIFF
--- a/src/lib/hardening/TestCoverageRaiser.ts
+++ b/src/lib/hardening/TestCoverageRaiser.ts
@@ -77,7 +77,8 @@ export class TestCoverageRaiser {
 
             const applied = await this.fs.applyDiffToFile(testPath, diff);
             if (!applied) {
-                await logDiffFailure(this.fs, testPath, diff);
+                const info = this.fs.lastDiffFailure || { file: testPath, diff, fileContent: testContent };
+                await logDiffFailure(this.fs, info.file, info.diff, info.fileContent, info.error);
                 break;
             }
 


### PR DESCRIPTION
## Summary
- track last diff failure information in `FileSystem`
- include full file contents and error when logging diff failure
- expose `ConversationManager.handleDiffFailure` to log a system message
- adapt `TestCoverageRaiser` and tests for new logging
- extend tests for diff failure conversation logging

## Testing
- `npm list jest` *(fails: package not installed)*
- `npx jest@29.7.0 --runInBand` *(fails: npm ERR canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68612137a1788330817e2ef285c20eb2