### PR TITLE
Implement iterative diff application with AI

### DIFF
--- a/src/lib/DiffApplier.ts
+++ b/src/lib/DiffApplier.ts
@@ -1,0 +1,49 @@
+import chalk from 'chalk';
+import { FileSystem, DiffFailureInfo } from './FileSystem';
+import { AIClient } from './AIClient';
+import DiffFixPrompts from './prompts/DiffFixPrompts';
+
+/**
+ * Applies a diff to a file, asking the AI to repair the diff if it fails.
+ * Attempts up to `maxAttempts` times and returns true if applied successfully.
+ */
+export async function applyDiffIteratively(
+    fs: FileSystem,
+    ai: AIClient,
+    filePath: string,
+    diff: string,
+    maxAttempts = 3
+): Promise<boolean> {
+    let currentDiff = diff;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const applied = await fs.applyDiffToFile(filePath, currentDiff);
+        if (applied) return true;
+
+        const info: DiffFailureInfo = fs.lastDiffFailure || {
+            file: filePath,
+            diff: currentDiff,
+            fileContent: (await fs.readFile(filePath)) ?? '',
+            error: undefined,
+        };
+
+        console.warn(
+            chalk.yellow(
+                `Diff application failed for ${filePath}. Attempt ${attempt + 1}/${maxAttempts}.`
+            )
+        );
+
+        const prompt = DiffFixPrompts.fixPatch(
+            filePath,
+            info.fileContent,
+            currentDiff,
+            info.error || ''
+        );
+        try {
+            currentDiff = await ai.getResponseTextFromAI([{ role: 'user', content: prompt }], false);
+        } catch (err) {
+            console.error(chalk.red('Failed to get corrected diff from AI:'), err);
+            return false;
+        }
+    }
+    return false;
+}

--- a/src/lib/__tests__/DiffApplier.test.ts
+++ b/src/lib/__tests__/DiffApplier.test.ts
@@ -1,0 +1,28 @@
+import { applyDiffIteratively } from '../DiffApplier';
+import { FileSystem, DiffFailureInfo } from '../FileSystem';
+import { AIClient } from '../AIClient';
+
+describe('applyDiffIteratively', () => {
+  it('requests fix from AI until diff applies', async () => {
+    const fsMock = {
+      applyDiffToFile: jest.fn(),
+      readFile: jest.fn().mockResolvedValue('content'),
+      lastDiffFailure: null as DiffFailureInfo | null,
+    } as unknown as FileSystem;
+
+    const aiMock = { getResponseTextFromAI: jest.fn() } as any as AIClient;
+
+    fsMock.applyDiffToFile
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    fsMock.lastDiffFailure = { file: 'a.txt', diff: 'bad', fileContent: 'content', error: 'err' };
+    aiMock.getResponseTextFromAI.mockResolvedValue('fixed');
+
+    const result = await applyDiffIteratively(fsMock, aiMock, 'a.txt', 'bad', 2);
+
+    expect(result).toBe(true);
+    expect(fsMock.applyDiffToFile).toHaveBeenNthCalledWith(1, 'a.txt', 'bad');
+    expect(aiMock.getResponseTextFromAI).toHaveBeenCalled();
+    expect(fsMock.applyDiffToFile).toHaveBeenNthCalledWith(2, 'a.txt', 'fixed');
+  });
+});

--- a/src/lib/hardening/TestCoverageRaiser.ts
+++ b/src/lib/hardening/TestCoverageRaiser.ts
@@ -5,6 +5,7 @@ import { FileSystem, logDiffFailure } from '../FileSystem';
 import { CommandService } from '../CommandService';
 import { AIClient } from '../AIClient';
 import { TestCoveragePrompts } from './TestCoveragePrompts';
+import { applyDiffIteratively } from '../DiffApplier';
 
 export class TestCoverageRaiser {
     private config: Config;
@@ -75,7 +76,7 @@ export class TestCoverageRaiser {
                 { role: 'user', content: prompt }
             ], false);
 
-            const applied = await this.fs.applyDiffToFile(testPath, diff);
+            const applied = await applyDiffIteratively(this.fs, this.aiClient, testPath, diff);
             if (!applied) {
                 const info = this.fs.lastDiffFailure || { file: testPath, diff, fileContent: testContent };
                 await logDiffFailure(this.fs, info.file, info.diff, info.fileContent, info.error);

--- a/src/lib/prompts/DiffFixPrompts.ts
+++ b/src/lib/prompts/DiffFixPrompts.ts
@@ -1,0 +1,4 @@
+export const DiffFixPrompts = {
+    fixPatch: (filePath: string, fileContent: string, brokenDiff: string, error: string): string => `Attempting to apply a unified diff to ${filePath} failed with error: ${error}\nCurrent file contents:\n\`\`\`\n${fileContent}\n\`\`\`\nBroken diff:\n\`\`\`diff\n${brokenDiff}\n\`\`\`\nPlease provide a corrected unified diff patch for ${filePath}. Respond only with the diff.`
+};
+export default DiffFixPrompts;


### PR DESCRIPTION
## Summary
- add `DiffFixPrompts` for repairing diffs
- add `applyDiffIteratively` helper to retry diff application using AI
- test the iterative diff applier
- use iterative diff applier in `TestCoverageRaiser`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68612e429f208330bc001abfa2fca614