### PR TITLE
Avoid AI retry on final diff failure

### DIFF
--- a/src/lib/DiffApplier.ts
+++ b/src/lib/DiffApplier.ts
@@ -19,6 +19,12 @@ export async function applyDiffIteratively(
         const applied = await fs.applyDiffToFile(filePath, currentDiff);
         if (applied) return true;
 
+        // If this was the last allowed attempt, exit early without
+        // requesting another diff from the AI.
+        if (attempt === maxAttempts - 1) {
+            return false;
+        }
+
         const info: DiffFailureInfo = fs.lastDiffFailure || {
             file: filePath,
             diff: currentDiff,


### PR DESCRIPTION
## Summary
- stop retrying diffs once the last attempt fails

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686134d3d3608330b4ff8af0f743c79e