### PR TITLE
Improve commit message prompt

### DIFF
--- a/src/lib/CommitMessageService.ts
+++ b/src/lib/CommitMessageService.ts
@@ -32,7 +32,7 @@ export class CommitMessageService {
         const files = await this.git.listModifiedFiles(projectRoot);
         const combined = `Changed files:\n${files.join('\n')}\n\n${diff}`;
 
-        const system = 'Generate a concise git commit message describing the following changes.';
+        const system = 'Generate a single, concise git commit message describing the following changes. Provide only one final message and do not offer multiple options.';
         if (countTokens(combined) <= this.maxTokens) {
             const messages: Message[] = [
                 { role: 'user', content: `${system}\n${combined}` }
@@ -42,7 +42,7 @@ export class CommitMessageService {
         }
 
         const chunks = this.chunkByTokens(combined, this.maxTokens - 500);
-        let messages: Message[] = [ { role: 'user', content: system + ' I will provide diff chunks. Reply with "COMMIT:" followed by the message when ready or "CONTINUE" if you need more.' } ];
+        let messages: Message[] = [ { role: 'user', content: system + ' I will provide diff chunks. Reply with "COMMIT:" followed by the single best message when ready or "CONTINUE" if you need more.' } ];
         let response = '';
         for (const chunk of chunks) {
             messages.push({ role: 'user', content: chunk });

--- a/src/lib/__tests__/CommitMessageService.test.ts
+++ b/src/lib/__tests__/CommitMessageService.test.ts
@@ -18,6 +18,7 @@ describe('CommitMessageService', () => {
         const call = (ai.getResponseTextFromAI as jest.Mock).mock.calls[0][0];
         expect(call[0].content).toMatch('a.ts');
         expect(call[0].content).toMatch('diff');
+        expect(call[0].content).toMatch(/single, concise git commit message/i);
     });
 
     test('chunks diff when it exceeds maxTokens', async () => {
@@ -32,5 +33,7 @@ describe('CommitMessageService', () => {
         const msg = await service.generateCommitMessage('/p');
         expect(msg).toBe('msg');
         expect(ai.getResponseTextFromAI as jest.Mock).toHaveBeenCalledTimes(2);
+        const firstCall = (ai.getResponseTextFromAI as jest.Mock).mock.calls[0][0];
+        expect(firstCall[0].content).toMatch(/single, concise git commit message/i);
     });
 });


### PR DESCRIPTION
## Summary
- clarify commit message request to always ask for one final message
- test updates for the new prompt wording

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6861375a1b448330ae687712e24319b7