### PR TITLE
Handle empty AI output during consolidation generation

### DIFF
--- a/src/lib/consolidation/__tests__/ConsolidationGeneratorRetry.test.ts
+++ b/src/lib/consolidation/__tests__/ConsolidationGeneratorRetry.test.ts
@@ -1,0 +1,31 @@
+import { ConsolidationGenerator } from '../ConsolidationGenerator';
+import { FileSystem } from '../../FileSystem';
+
+const fsMock = new FileSystem() as jest.Mocked<FileSystem>;
+
+describe('ConsolidationGenerator retry logic', () => {
+    it('retries when AI returns empty content', async () => {
+        const config: any = { gemini: { generation_max_retries: 2, generation_retry_base_delay_ms: 1 } };
+        const aiClient = { getResponseTextFromAI: jest.fn() } as any;
+        const generator = new ConsolidationGenerator(config, fsMock, aiClient, '/project');
+
+        jest.spyOn(generator as any, '_readCurrentFileContent').mockResolvedValue(null);
+        const callSpy = jest
+            .spyOn(generator as any, '_callGenerationAIWithRetry')
+            .mockResolvedValueOnce('')
+            .mockResolvedValueOnce('')
+            .mockResolvedValueOnce('content');
+
+        const result = await generator.generate(
+            [],
+            '',
+            { operations: [{ filePath: 'a.txt', action: 'CREATE' }] },
+            'log.jsonl',
+            false,
+            'Pro'
+        );
+
+        expect(callSpy).toHaveBeenCalledTimes(3);
+        expect(result['a.txt']).toBe('content');
+    });
+});


### PR DESCRIPTION
## Summary
- retry file generation when AI returns empty content
- test retry behavior in ConsolidationGenerator

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686140c7f37483308538eae295ad5058