### PR TITLE
Fix Gemini2FlashModel tests

### DIFF
--- a/src/lib/models/Gemini2FlashModel.test.ts
+++ b/src/lib/models/Gemini2FlashModel.test.ts
@@ -1,46 +1,91 @@
-import { Gemini2FlashModel } from './Gemini2FlashModel'; // Adjust path if necessary
+import Gemini2FlashModel from './Gemini2FlashModel';
+import { FinishReason } from '@google/generative-ai';
+
+// Mock the generative AI library so no real network calls occur
+jest.mock('@google/generative-ai', () => {
+  return {
+    FinishReason: {
+      STOP: 'STOP',
+      SAFETY: 'SAFETY',
+      MAX_TOKENS: 'MAX_TOKENS',
+      RECITATION: 'RECITATION'
+    },
+    GoogleGenerativeAI: class {
+      // minimal mock that returns a dummy model with the methods used by the class
+      getGenerativeModel() {
+        return {
+          startChat: jest.fn(() => ({ sendMessage: jest.fn() })),
+          generateContent: jest.fn()
+        };
+      }
+    }
+  };
+});
+
+// Helper to create the minimal configuration object expected by the model
+const createConfig = () => ({
+  gemini: {
+    api_key: 'k',
+    subsequent_chat_model_name: 'flash',
+    generation_max_retries: 0,
+    generation_retry_base_delay_ms: 1,
+    max_output_tokens: 5
+  }
+});
 
 describe('Gemini2FlashModel', () => {
   let model: Gemini2FlashModel;
 
-  // Initialize a new model before each test to ensure isolation
   beforeEach(() => {
-    model = new Gemini2FlashModel();
+    model = new Gemini2FlashModel(createConfig() as any);
   });
 
-  it('should be instantiable', () => {
-    expect(model).toBeInstanceOf(Gemini2FlashModel);
-  });
-
-  // Assuming a method `toFlashContent` that processes an array of Gemini-like parts
-  // and converts them into a single string for 'Flash' content.
-  describe('toFlashContent', () => {
-    it('should convert a single Gemini text part to Flash content', () => {
-      const geminiParts = [{ text: 'Hello, world!' }];
-      const expectedFlashContent = 'Hello, world!';
-      const result = model.toFlashContent(geminiParts);
-      expect(result).toEqual(expectedFlashContent);
-    });
-
-    it('should concatenate multiple Gemini text parts into a single string', () => {
-      const geminiParts = [
-        { text: 'First part.' },
-        { text: ' Second part.' },
-        { text: ' Third part.' },
+  describe('convertToGeminiConversation', () => {
+    it('merges consecutive messages with the same role and strips system messages', () => {
+      const messages = [
+        { role: 'user', content: 'a' },
+        { role: 'assistant', content: 'b' },
+        { role: 'assistant', content: 'c' },
+        { role: 'system', content: 'ignore' },
+        { role: 'user', content: 'd' }
       ];
-      const expectedFlashContent = 'First part. Second part. Third part.';
-      const result = model.toFlashContent(geminiParts);
-      expect(result).toEqual(expectedFlashContent);
+
+      const result = model.convertToGeminiConversation(messages as any);
+      expect(result).toEqual([
+        { role: 'user', parts: [{ text: 'a' }] },
+        { role: 'model', parts: [{ text: 'b' }, { text: 'c' }] },
+        { role: 'user', parts: [{ text: 'd' }] }
+      ]);
+    });
+  });
+
+  describe('handleError', () => {
+    it('classifies network errors', () => {
+      const err = new Error('FETCH_ERROR');
+      (err as any).name = 'FetchError';
+      expect(() => model.handleError(err, 'flash')).toThrow(
+        /AI API Error \(NETWORK_ERROR\)/
+      );
     });
 
-    it('should return an empty string for an empty array of Gemini parts', () => {
-      const geminiParts: any[] = [];
-      const expectedFlashContent = '';
-      const result = model.toFlashContent(geminiParts);
-      expect(result).toEqual(expectedFlashContent);
+    it('classifies API errors based on status', () => {
+      const err = { status: 429, message: 'Too many' } as any;
+      expect(() => model.handleError(err, 'flash')).toThrow(
+        /AI API Error \(RATE_LIMIT\)/
+      );
     });
 
-    // Add more tests here to cover different part types (e.g., inlineData for images)
-    // or error handling, once the actual implementation details are known.
+    it('falls back to general error handling', () => {
+      const err = new Error('boom');
+      const thrown = (() => {
+        try {
+          model.handleError(err, 'flash');
+        } catch (e) {
+          return e as any;
+        }
+      })();
+      expect(thrown.code).toBe('UNKNOWN');
+      expect(thrown.message).toContain('boom');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- rewrite `Gemini2FlashModel.test.ts`
- mock generative-ai module for isolation
- add tests for `convertToGeminiConversation` and `handleError`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_686147d494b48330a9c047d6d6c55348