### PR TITLE
Allow model selection during harden phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ When the TypeScript feedback loop is enabled, Kai runs `npx tsc --noEmit` after 
 
 ### Hardening Workflow
 
-Kai can also raise your test coverage automatically. The `TestCoverageRaiser` utility runs your Jest suite with coverage enabled, identifies the file with the lowest coverage, and asks the AI to write a new test for it. Launch it by running `kai` and choosing **Harden** from the main menu (select the desired test framework). Kai will iterate up to `project.coverage_iterations` times, re-running coverage and generating tests until coverage improves. See [docs/100coverageplay.md](docs/100coverageplay.md) for a phased approach to reaching 100%.
+Kai can also raise your test coverage automatically. The `TestCoverageRaiser` utility runs your Jest suite with coverage enabled, identifies the file with the lowest coverage, and asks the AI to write a new test for it. Launch it by running `kai` and choosing **Harden** from the main menu (select the desired test framework). Kai will iterate up to `project.coverage_iterations` times, re-running coverage and generating tests until coverage improves. See [docs/100coverageplay.md](docs/100coverageplay.md) for a phased approach to reaching 100%. During hardening you can now pick which Gemini model to use, mirroring the options available for conversations and consolidation.
 
 ## Development
 

--- a/src/kai.ts
+++ b/src/kai.ts
@@ -357,6 +357,13 @@ async function main() {
             } else if (mode === 'Harden') {
                  if (!codeProcessor) throw new Error("CodeProcessor not initialized.");
                  const hardenResult = interactionResult as HardenInteractionResult;
+                 if (hardenResult.selectedModel && config && config.gemini.model_name !== hardenResult.selectedModel) {
+                     console.log(chalk.blue(`Overriding default model. Using: ${chalk.cyan(hardenResult.selectedModel)}`));
+                     config.gemini.model_name = hardenResult.selectedModel;
+                     codeProcessor.updateAIClient(new AIClient(config));
+                 } else if (config) {
+                     console.log(chalk.blue(`Using AI Model: ${chalk.cyan(config.gemini.model_name)}`));
+                 }
                  await codeProcessor.processHardeningRequest(hardenResult.tool);
                  console.log(chalk.magenta('🏁 Hardening process completed.'));
 

--- a/src/lib/UserInterface.ts
+++ b/src/lib/UserInterface.ts
@@ -46,6 +46,7 @@ interface ScaffoldProjectInteractionResult {
 interface HardenInteractionResult {
     mode: 'Harden';
     tool: 'jest';
+    selectedModel: string;
 }
 
 // Define the structure for the fallback error
@@ -504,7 +505,28 @@ class UserInterface {
                         choices: frameworks,
                     }
                 ]);
-                return { mode: 'Harden', tool: toolChoice.toLowerCase() as 'jest' };
+                const primaryModel = this.config.gemini.model_name;
+                const secondaryModel = this.config.gemini.subsequent_chat_model_name;
+                const modelChoices = [
+                    {
+                        name: `Primary Model (${primaryModel}) - Recommended for complex tasks / generation`,
+                        value: primaryModel
+                    },
+                    {
+                        name: `Secondary Model (${secondaryModel}) - Recommended for quick interactions / analysis`,
+                        value: secondaryModel
+                    },
+                ];
+                const { modelChoice } = await inquirer.prompt([
+                    {
+                        type: 'list',
+                        name: 'modelChoice',
+                        message: 'Select the AI model to use for this operation:',
+                        choices: modelChoices,
+                        default: primaryModel,
+                    },
+                ]);
+                return { mode: 'Harden', tool: toolChoice.toLowerCase() as 'jest', selectedModel: modelChoice };
             }
 
             // --- Remaining modes require Model selection ---


### PR DESCRIPTION
## Summary
- prompt for AI model when selecting Harden mode
- override configured model before running hardening
- document model selection option for hardening

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68615bf62508833097aea0fccac46ad7