### PR TITLE
Fix diff apply leaving empty files

### DIFF
--- a/src/lib/FileSystem.ts
+++ b/src/lib/FileSystem.ts
@@ -409,6 +409,16 @@ class FileSystem {
                     return false;
                 }
             }
+
+            // If the patch was not a delete operation but produced an empty
+            // result, treat this as a failure. This prevents truncating files
+            // when the diff is incomplete (e.g., missing additions).
+            if (!isDelete && original.trim().length > 0 && result.trim().length === 0) {
+                this.lastDiffFailure = { file: filePath, diff: cleanedDiff, fileContent: original, error: 'Patch resulted in empty file' };
+                await logDiffFailure(this, filePath, cleanedDiff, original, 'Patch resulted in empty file');
+                return false;
+            }
+
             await this.writeFile(filePath, result);
             return true;
         } catch (err) {


### PR DESCRIPTION
## Summary
- prevent empty file when AI-generated diff lacks additions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615ebe6f308330a94e913119115464