### PR TITLE
Improve BaseModel test coverage

### DIFF
--- a/src/lib/models/BaseModel.test.ts
+++ b/src/lib/models/BaseModel.test.ts
@@ -1,30 +1,43 @@
-import { BaseModel } from './BaseModel';
+import BaseModel from './BaseModel';
 
 describe('BaseModel', () => {
-  it('should initialize with provided data', () => {
-    const data = { id: 'testId1', name: 'Test Model One', value: 100 };
-    const model = new BaseModel(data);
-
-    expect(model).toBeDefined();
-    expect(model.id).toBe('testId1');
-    expect(model.name).toBe('Test Model One');
-    expect(model.value).toBe(100);
+  it('stores the provided config', () => {
+    const config = {foo: 'bar'};
+    const model = new BaseModel(config as any);
+    expect(model.config).toBe(config);
   });
 
-  it('should initialize without data if none is provided', () => {
-    const model = new BaseModel();
-    expect(model).toBeDefined();
-    // Assuming BaseModel doesn't set default 'id' or other properties unless explicitly passed
-    expect(model.id).toBeUndefined();
+  it('getResponseFromAI throws an error by default', async () => {
+    const model = new BaseModel({});
+    await expect(model.getResponseFromAI({})).rejects.toThrow(
+      'getResponseFromAI must be implemented in derived classes'
+    );
   });
 
-  it('should return a plain object representation using toJSON()', () => {
-    const data = { id: 'testId2', description: 'A description for test model two' };
-    const model = new BaseModel(data);
+  describe('flattenMessages', () => {
+    it('logs an error and returns empty array when input is not an array', () => {
+      const model = new BaseModel({});
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const result = model.flattenMessages('bad' as any);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'flattenMessages expects an array of messages.'
+      );
+      expect(result).toEqual([]);
+      errorSpy.mockRestore();
+    });
 
-    const json = model.toJSON();
-    expect(json).toEqual(data);
-    expect(json).not.toBeInstanceOf(BaseModel); // Ensure it's a plain object, not an instance
-    expect(typeof json).toBe('object');
+    it('filters out messages without required structure', () => {
+      const model = new BaseModel({});
+      const valid1 = { role: 'user', parts: [{ text: 'hello' }] };
+      const valid2 = { role: 'bot', parts: [{ text: 'hi' }] };
+      const messages = [
+        valid1,
+        { role: 'missingParts' },
+        { role: 'badText', parts: [{ text: 123 }] },
+        valid2,
+      ];
+      const result = model.flattenMessages(messages as any);
+      expect(result).toEqual([valid1, valid2]);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- fix import in BaseModel test
- add thorough tests for constructor, error handling and message filtering

## Testing
- `npm test --silent`
- `npx jest --coverage --maxWorkers=2`

------
https://chatgpt.com/codex/tasks/task_e_6861672736c48330a21dcdd74bc91cd4