### PR TITLE
Add comprehensive tests for Gemini2ProModel

### DIFF
--- a/src/lib/models/Gemini2ProModel.test.ts
+++ b/src/lib/models/Gemini2ProModel.test.ts
@@ -9,8 +9,11 @@ var mockResponseText = jest.fn();
 var mockResponse = { text: mockResponseText };
 
 var mockGenerateContent = jest.fn();
+var mockSendMessage = jest.fn();
+var mockStartChat = jest.fn(() => ({ sendMessage: mockSendMessage }));
 var mockGetGenerativeModel = jest.fn(() => ({
   generateContent: mockGenerateContent,
+  startChat: mockStartChat,
 }));
 
 // Renamed for clarity: this is the spy that tracks the *constructor calls* for GoogleGenerativeAI.
@@ -71,6 +74,14 @@ jest.mock('../Config', () => {
   return { Config: MockConfig }; // Export the mock class as 'Config'
 });
 
+// Mock InteractivePromptReviewer with a simple class exposing reviewPrompt
+var mockReviewPrompt = jest.fn();
+jest.mock('../UserInteraction/InteractivePromptReviewer', () => ({
+  InteractivePromptReviewer: jest.fn().mockImplementation(() => ({
+    reviewPrompt: mockReviewPrompt,
+  })),
+}));
+
 describe('Gemini2ProModel', () => {
   const MOCK_API_KEY = 'test-api-key';
   const MOCK_PROMPT = 'Hello, Gemini!';
@@ -79,7 +90,7 @@ describe('Gemini2ProModel', () => {
   beforeEach(() => {
     jest.clearAllMocks(); // Clears all call histories and mock return values
     // Re-set the return value for mockGetGenerativeModel because clearAllMocks would clear it
-    mockGetGenerativeModel.mockReturnValue({ generateContent: mockGenerateContent });
+    mockGetGenerativeModel.mockReturnValue({ generateContent: mockGenerateContent, startChat: mockStartChat });
     // No need to re-mock mockGoogleGenerativeAI.mockImplementation here, it's defined globally
   });
 
@@ -120,6 +131,18 @@ describe('Gemini2ProModel', () => {
     expect(mockGoogleGenerativeAIConstructor).toHaveBeenCalledWith(MOCK_API_KEY);
   });
 
+  it('throws if generative model cannot be created', () => {
+    const cfg = createMockConfig(MOCK_API_KEY);
+    mockGetGenerativeModel.mockImplementation(() => { throw new Error('fail'); });
+    expect(() => new Gemini2ProModel(cfg)).toThrow(/Failed to get generative model/);
+  });
+
+  it('getResponseFromAI rejects empty messages', async () => {
+    const cfg = createMockConfig(MOCK_API_KEY);
+    const model = new Gemini2ProModel(cfg);
+    await expect(model.getResponseFromAI([] as any)).rejects.toThrow('Cannot get AI response');
+  });
+
   // Define the GenerateContentRequest for the tests
   const MOCK_GENERATE_CONTENT_REQUEST: GenerateContentRequest = {
     contents: [{ role: 'user', parts: [{ text: MOCK_PROMPT }] }]
@@ -139,7 +162,7 @@ describe('Gemini2ProModel', () => {
       // Reset mock implementations for the generation process
       mockResponseText.mockReturnValue(MOCK_GENERATED_TEXT);
       mockGenerateContent.mockResolvedValue({ response: mockResponse });
-      mockGetGenerativeModel.mockReturnValue({ generateContent: mockGenerateContent }); // Ensure it's set for this test
+      mockGetGenerativeModel.mockReturnValue({ generateContent: mockGenerateContent, startChat: mockStartChat }); // Ensure it's set for this test
     });
 
     it('should call the Gemini API with the default model and return the generated text', async () => {
@@ -168,7 +191,7 @@ describe('Gemini2ProModel', () => {
       // Reset generateContent related mocks after clearing
       mockResponseText.mockReturnValue(MOCK_GENERATED_TEXT);
       mockGenerateContent.mockResolvedValue({ response: mockResponse });
-      mockGetGenerativeModel.mockReturnValue({ generateContent: mockGenerateContent }); // Ensure it's set for this test
+      mockGetGenerativeModel.mockReturnValue({ generateContent: mockGenerateContent, startChat: mockStartChat }); // Ensure it's set for this test
 
       const result = await model.generateContent(MOCK_GENERATE_CONTENT_REQUEST);
 
@@ -193,6 +216,188 @@ describe('Gemini2ProModel', () => {
       expect(mockGetGenerativeModel).toHaveBeenCalledTimes(1);
       expect(mockGenerateContent).toHaveBeenCalledTimes(1);
       expect(mockResponseText).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('Gemini2ProModel additional methods', () => {
+  const config = new Config() as jest.Mocked<Config>;
+  config.gemini.api_key = 'k';
+  const EDGE_REQUEST: GenerateContentRequest = {
+    contents: [{ role: 'user', parts: [{ text: 'x' }] }]
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetGenerativeModel.mockReturnValue({ generateContent: mockGenerateContent, startChat: mockStartChat });
+  });
+
+  test('convertToGeminiConversation merges and warns when last message is model', () => {
+    const model = new Gemini2ProModel(config);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const result = model.convertToGeminiConversation([
+      { role: 'user', content: 'a' },
+      { role: 'assistant', content: 'b' },
+      { role: 'assistant', content: 'c' },
+      { role: 'system', content: 'ignore' },
+      { role: 'assistant', content: 'd' },
+    ] as any);
+    expect(result).toEqual([
+      { role: 'user', parts: [{ text: 'a' }] },
+      { role: 'model', parts: [{ text: 'b' }, { text: 'c' }, { text: 'd' }] },
+    ]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  describe('queryGeminiChat', () => {
+    let model: Gemini2ProModel;
+
+    beforeEach(() => {
+      mockSendMessage.mockResolvedValue({ response: { text: () => 'ok' } });
+      model = new Gemini2ProModel(config);
+    });
+
+    test('sends prompt directly when interactive review disabled', async () => {
+      const history = model.convertToGeminiConversation([{ role: 'user', content: 'p' }] as any);
+      const text = await model.queryGeminiChat(history);
+      expect(mockReviewPrompt).not.toHaveBeenCalled();
+      expect(mockStartChat).toHaveBeenCalled();
+      expect(mockSendMessage).toHaveBeenCalledWith('p');
+      expect(text).toBe('ok');
+    });
+
+    test('uses reviewed prompt when interactive review enabled', async () => {
+      config.gemini.interactive_prompt_review = true;
+      mockReviewPrompt.mockResolvedValue('edited');
+      model = new Gemini2ProModel(config);
+      const history = model.convertToGeminiConversation([{ role: 'user', content: 'p' }] as any);
+      const text = await model.queryGeminiChat(history);
+      expect(mockReviewPrompt).toHaveBeenCalledWith('p');
+      expect(mockSendMessage).toHaveBeenCalledWith('edited');
+      expect(text).toBe('ok');
+    });
+
+    test('returns empty string when review cancelled', async () => {
+      config.gemini.interactive_prompt_review = true;
+      mockReviewPrompt.mockResolvedValue(null);
+      model = new Gemini2ProModel(config);
+      const history = model.convertToGeminiConversation([{ role: 'user', content: 'p' }] as any);
+      const text = await model.queryGeminiChat(history);
+      expect(text).toBe('');
+    });
+
+    test('delegates errors to handleError', async () => {
+      const err = new Error('bad');
+      mockSendMessage.mockResolvedValue({ response: {} });
+      config.gemini.interactive_prompt_review = false;
+      model = new Gemini2ProModel(config);
+      const history = model.convertToGeminiConversation([{ role: 'user', content: 'p' }] as any);
+      const spy = jest.spyOn(model, 'handleError').mockImplementation(() => { throw err; });
+      await expect(model.queryGeminiChat(history)).rejects.toThrow('bad');
+      spy.mockRestore();
+    });
+
+    test('throws when last message is not user', async () => {
+      model = new Gemini2ProModel(config);
+      const history = [{ role: 'model', parts: [{ text: 'a' }] }] as any;
+      await expect(model.queryGeminiChat(history)).rejects.toThrow('Internal Error');
+    });
+  });
+
+  describe('handleError', () => {
+    let model: Gemini2ProModel;
+    beforeEach(() => {
+      model = new Gemini2ProModel(config);
+    });
+
+    test('classifies network errors', () => {
+      const err = new Error('FETCH_ERROR');
+      (err as any).name = 'FetchError';
+      expect(() => model.handleError(err, 'pro')).toThrow(/NETWORK_ERROR/);
+    });
+
+    test('classifies API errors based on status', () => {
+      const err = { status: 429, message: 'Too many' } as any;
+      expect(() => model.handleError(err, 'pro')).toThrow(/RATE_LIMIT/);
+    });
+
+    test('falls back to general error handling', () => {
+      const err = new Error('boom');
+      const thrown = (() => { try { model.handleError(err, 'pro'); } catch (e) { return e as any; }})();
+      expect(thrown.code).toBe('UNKNOWN');
+      expect(thrown.message).toContain('boom');
+    });
+
+    test('classifies google AI errors', () => {
+      const err = new Error('[GoogleGenerativeAI Error] backend error');
+      const thrown = (() => { try { model.handleError(err, 'pro'); } catch (e) { return e as any; }})();
+      expect(thrown.code).toBe('SERVER_OVERLOADED');
+    });
+
+    test('classifies safety errors', () => {
+      const err = new Error('SAFETY violation');
+      const thrown = (() => { try { model.handleError(err, 'pro'); } catch (e) { return e as any; }})();
+      expect(thrown.code).toBe('SAFETY_BLOCK');
+    });
+
+    test('returns code from error.code field', () => {
+      const err: any = new Error('x');
+      err.code = 'CUSTOM';
+      const thrown = (() => { try { model.handleError(err, 'pro'); } catch (e) { return e as any; }})();
+      expect(thrown.code).toBe('CUSTOM');
+    });
+
+    test('handles unknown non-error objects', () => {
+      const thrown = (() => { try { model.handleError({} as any, 'pro'); } catch (e) { return e as any; }})();
+      expect(thrown.code).toBe('UNKNOWN');
+    });
+  });
+
+  describe('generateContent edge cases', () => {
+    let model: Gemini2ProModel;
+
+    beforeEach(() => {
+      config.gemini.generation_max_retries = 1;
+      config.gemini.generation_retry_base_delay_ms = 0;
+      model = new Gemini2ProModel(config);
+      mockResponseText.mockReturnValue('out');
+    });
+
+    test('retries on retryable error then succeeds', async () => {
+      jest.useFakeTimers();
+      const err = new Error('timeout');
+      (err as any).code = 'NETWORK_ERROR';
+      mockGenerateContent.mockRejectedValueOnce(err).mockResolvedValueOnce({ response: mockResponse });
+      const promise = model.generateContent(EDGE_REQUEST);
+      await jest.runOnlyPendingTimersAsync();
+      const result = await promise;
+      expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+      expect(result.response).toBe(mockResponse);
+      jest.useRealTimers();
+    });
+
+    test('throws block error and passes to handleError', async () => {
+      mockGenerateContent.mockResolvedValue({ response: { candidates: [{ finishReason: FinishReason.SAFETY, safetyRatings: [1] }] } });
+      const spy = jest.spyOn(model, 'handleError').mockImplementation(() => { throw new Error('block'); });
+      await expect(model.generateContent(EDGE_REQUEST)).rejects.toThrow('block');
+      expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
+
+    test('warns when no text produced but finishReason STOP', async () => {
+      mockGenerateContent.mockResolvedValue({ response: { candidates: [{ finishReason: FinishReason.STOP, content: { parts: [] } }] } });
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      await model.generateContent(EDGE_REQUEST);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    test('handles missing response object', async () => {
+      mockGenerateContent.mockResolvedValue({});
+      const spy = jest.spyOn(model, 'handleError').mockImplementation(() => { throw new Error('empty'); });
+      await expect(model.generateContent(EDGE_REQUEST)).rejects.toThrow('empty');
+      spy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary
- expand Gemini2ProModel tests to cover edge cases
- exercise queryGeminiChat behaviour, error paths and handleError
- add generateContent retry and block tests

## Testing
- `yarn test --coverage --maxWorkers=2`

------
https://chatgpt.com/codex/tasks/task_e_68616b4714ec8330a88a04445822c7e4