### PR TITLE
Improve TypeScriptLoop branch coverage

### DIFF
--- a/src/lib/consolidation/__tests__/TypeScriptLoop.test.ts
+++ b/src/lib/consolidation/__tests__/TypeScriptLoop.test.ts
@@ -20,4 +20,46 @@ describe('TypeScriptLoop', () => {
         expect(res.success).toBe(false);
         expect(res.log).toContain('err');
     });
+
+    it('skips when tsconfig is missing and autofix disabled', async () => {
+        const fs = { access: jest.fn().mockRejectedValue(new Error('missing')) } as any;
+        const commandService = { run: jest.fn() } as any;
+        const config = { project: { typescript_autofix: false } } as any;
+        const loop = new TypeScriptLoop(commandService, fs, config);
+        const res = await loop.run('/project');
+        expect(commandService.run).not.toHaveBeenCalled();
+        expect(res).toEqual({ success: true, log: '' });
+    });
+
+    it('runs tsc when tsconfig missing but autofix enabled', async () => {
+        const fs = { access: jest.fn().mockRejectedValue(new Error('missing')) } as any;
+        const commandService = { run: jest.fn().mockResolvedValue({ stdout: ' ok ', stderr: ' warn ' }) } as any;
+        const config = { project: { typescript_autofix: true } } as any;
+        const loop = new TypeScriptLoop(commandService, fs, config);
+        const res = await loop.run('/project');
+        expect(commandService.run).toHaveBeenCalledWith('npx tsc --noEmit', { cwd: '/project' });
+        expect(res).toEqual({ success: true, log: 'ok\nwarn' });
+    });
+
+    it('handles error with stdout and message fields', async () => {
+        const fs = { access: jest.fn().mockResolvedValue(undefined) } as any;
+        const err: any = new Error('boom');
+        err.stdout = ' out ';
+        const commandService = { run: jest.fn().mockRejectedValue(err) } as any;
+        const config = { project: { typescript_autofix: true } } as any;
+        const loop = new TypeScriptLoop(commandService, fs, config);
+        const res = await loop.run('/project');
+        expect(res).toEqual({ success: false, log: 'out\nboom' });
+    });
+
+    it('handles error without stderr or message', async () => {
+        const fs = { access: jest.fn().mockResolvedValue(undefined) } as any;
+        const err: any = new Error('');
+        err.message = '';
+        const commandService = { run: jest.fn().mockRejectedValue(err) } as any;
+        const config = { project: { typescript_autofix: true } } as any;
+        const loop = new TypeScriptLoop(commandService, fs, config);
+        const res = await loop.run('/project');
+        expect(res).toEqual({ success: false, log: '' });
+    });
 });


### PR DESCRIPTION
## Summary
- add missing cases to TypeScriptLoop tests
- cover skipping path, auto-fix without tsconfig, and error branches

## Testing
- `yarn jest src/lib/consolidation/__tests__/TypeScriptLoop.test.ts --coverage --collectCoverageFrom=src/lib/consolidation/feedback/TypeScriptLoop.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68617300bb5c8330b3a5e5fa35dcdbba