### PR TITLE
Add sync FileSystem helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/marked": "^6.0.0",
     "@types/node": "^22.13.10",
+    "mock-fs": "^5.1.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2"
   }

--- a/src/lib/FileSystem.ts
+++ b/src/lib/FileSystem.ts
@@ -1,4 +1,5 @@
 // File: src/lib/FileSystem.ts
+import fs from 'fs';
 import fsPromises from 'fs/promises'; // Use promises API
 import { Stats } from 'fs'; // Import Stats type from base 'fs'
 import os from 'os';
@@ -26,6 +27,29 @@ const SAFE_TO_IGNORE_FOR_EMPTY_CHECK = new Set([
 ]);
 
 class FileSystem {
+
+    // Synchronous wrappers for backward compatibility
+    static existsSync(p: string): boolean {
+        return fs.existsSync(p);
+    }
+
+    static readFileSync(p: string, encoding: BufferEncoding = 'utf-8'): string {
+        return fs.readFileSync(p, { encoding }) as unknown as string;
+    }
+
+    static writeFileSync(p: string, content: string): void {
+        const dir = path.dirname(p);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(p, content, 'utf-8');
+    }
+
+    static mkdirSync(dir: string): void {
+        fs.mkdirSync(dir, { recursive: true });
+    }
+
+    static rmSync(p: string, options?: fs.RmOptions): void {
+        fs.rmSync(p, options as fs.RmOptions);
+    }
 
     // --- Common FS methods (remain unchanged) ---
     async access(filePath: string): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,6 +2079,11 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+mock-fs@^5.1.2:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-5.5.0.tgz#94a46d299aaa588e735a201cbe823c876e91f385"
+  integrity sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==
+
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"


### PR DESCRIPTION
## Summary
- support synchronous FS methods for older tests
- include mock-fs as dev dependency

## Testing
- `yarn test src/lib/__tests__/FileSystem.test.ts`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68617f1867a48330a7d46ff72b45c3fc