### PR TITLE
Add sync FileSystem helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,10 @@
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/marked": "^6.0.0",
+    "@types/mock-fs": "4.13.4",
     "@types/node": "^22.13.10",
     "jest": "^29.7.0",
+    "mock-fs": "^5.1.2",
     "ts-jest": "^29.1.2"
   }
 }

--- a/src/lib/FileSystem.test.ts
+++ b/src/lib/FileSystem.test.ts
@@ -1,0 +1,79 @@
+import mockFs from 'mock-fs';
+import path from 'path';
+import { FileSystem } from './FileSystem';
+
+describe('FileSystem synchronous helpers', () => {
+  const testDir = '/tmp/test-dir';
+  const testFile = path.join(testDir, 'file.txt');
+  const binaryFile = path.join(testDir, 'bin.bin');
+  const subDir = path.join(testDir, 'sub');
+  const fileInNewDir = path.join(subDir, 'new.txt');
+  const nonExistentPath = path.join(testDir, 'missing.txt');
+  const nonEmptyDir = path.join(testDir, 'nonempty');
+
+  beforeEach(() => {
+    mockFs({
+      [testDir]: {
+        'file.txt': 'Hello, World!',
+        'bin.bin': Buffer.from([1, 2, 3]),
+        'existing-dir': {},
+        'nonempty': { 'a.txt': 'data' },
+      },
+    });
+  });
+
+  afterEach(() => {
+    mockFs.restore();
+  });
+
+  it('existsSync checks files and directories', () => {
+    expect(FileSystem.existsSync(testFile)).toBe(true);
+    expect(FileSystem.existsSync(testDir)).toBe(true);
+    expect(FileSystem.existsSync(nonExistentPath)).toBe(false);
+  });
+
+  it('readFileSync reads and errors appropriately', () => {
+    expect(FileSystem.readFileSync(testFile)).toBe('Hello, World!');
+    expect(() => FileSystem.readFileSync(nonExistentPath)).toThrow();
+    expect(FileSystem.readFileSync(binaryFile, 'latin1')).toBe('\x01\x02\x03');
+    expect(() => FileSystem.readFileSync(testDir)).toThrow();
+  });
+
+  it('writeFileSync writes files and directories', () => {
+    const newFile = path.join(testDir, 'new.txt');
+    FileSystem.writeFileSync(newFile, 'New content');
+    expect(FileSystem.existsSync(newFile)).toBe(true);
+    expect(FileSystem.readFileSync(newFile)).toBe('New content');
+
+    FileSystem.writeFileSync(testFile, 'Overwritten content');
+    expect(FileSystem.readFileSync(testFile)).toBe('Overwritten content');
+
+    FileSystem.writeFileSync(fileInNewDir, 'Content in new dir');
+    expect(FileSystem.existsSync(subDir)).toBe(true);
+    expect(FileSystem.readFileSync(fileInNewDir)).toBe('Content in new dir');
+
+    expect(() => FileSystem.writeFileSync(testDir, 'some content')).toThrow();
+  });
+
+  it('mkdirSync behaves like fs.mkdirSync', () => {
+    FileSystem.mkdirSync(subDir);
+    expect(FileSystem.existsSync(subDir)).toBe(true);
+    expect(() => FileSystem.mkdirSync(testFile)).toThrow();
+    expect(() => FileSystem.mkdirSync(testDir)).not.toThrow();
+    expect(FileSystem.existsSync(testDir)).toBe(true);
+  });
+
+  it('rmSync removes files and directories', () => {
+    FileSystem.rmSync(testFile);
+    expect(FileSystem.existsSync(testFile)).toBe(false);
+
+    FileSystem.rmSync(path.join(testDir, 'existing-dir'), { recursive: true });
+    expect(FileSystem.existsSync(path.join(testDir, 'existing-dir'))).toBe(false);
+
+    expect(() => FileSystem.rmSync(nonExistentPath)).toThrow();
+    expect(() => FileSystem.rmSync(nonExistentPath, { force: true })).not.toThrow();
+
+    expect(() => FileSystem.rmSync(nonEmptyDir)).toThrow();
+    expect(FileSystem.existsSync(nonEmptyDir)).toBe(true);
+  });
+});

--- a/src/lib/FileSystem.ts
+++ b/src/lib/FileSystem.ts
@@ -1,4 +1,5 @@
 // File: src/lib/FileSystem.ts
+import fs from 'fs';
 import fsPromises from 'fs/promises'; // Use promises API
 import { Stats } from 'fs'; // Import Stats type from base 'fs'
 import os from 'os';
@@ -26,6 +27,36 @@ const SAFE_TO_IGNORE_FOR_EMPTY_CHECK = new Set([
 ]);
 
 class FileSystem {
+
+    // Synchronous wrappers for backward compatibility
+    static existsSync(p: string): boolean {
+        return fs.existsSync(p);
+    }
+
+    static readFileSync(p: string, encoding: BufferEncoding = 'utf-8'): string {
+        return fs.readFileSync(p, { encoding }) as unknown as string;
+    }
+
+    static writeFileSync(p: string, content: string): void {
+        const dir = path.dirname(p);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(p, content, 'utf-8');
+    }
+
+    static mkdirSync(dir: string): void {
+        fs.mkdirSync(dir, { recursive: true });
+    }
+
+    static rmSync(p: string, options?: fs.RmOptions): void {
+        try {
+            fs.rmSync(p, options as fs.RmOptions);
+        } catch (err: any) {
+            if (options?.force && err?.code === 'ENOENT') {
+                return; // swallow missing path error when force is true
+            }
+            throw err;
+        }
+    }
 
     // --- Common FS methods (remain unchanged) ---
     async access(filePath: string): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,6 +703,13 @@
   dependencies:
     marked "*"
 
+"@types/mock-fs@4.13.4":
+  version "4.13.4"
+  resolved "https://registry.yarnpkg.com/@types/mock-fs/-/mock-fs-4.13.4.tgz#e73edb4b4889d44d23f1ea02d6eebe50aa30b09a"
+  integrity sha512-mXmM0o6lULPI8z3XNnQCpL0BGxPwx1Ul1wXYEPBGl4efShyxW2Rln0JOPEWGyZaYZMM6OVXM/15zUuFMY52ljg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@^22.13.10":
   version "22.13.10"
   resolved "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz"
@@ -2078,6 +2085,11 @@ minimatch@^5.0.1:
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
     brace-expansion "^2.0.1"
+
+mock-fs@^5.1.2:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-5.5.0.tgz#94a46d299aaa588e735a201cbe823c876e91f385"
+  integrity sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==
 
 ms@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
## Summary
- support synchronous FS methods for older tests
- include mock-fs typings
- add tests for new sync wrappers
- handle rmSync ENOENT with force option

## Testing
- `yarn test src/lib/FileSystem.test.ts`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68617f1867a48330a7d46ff72b45c3fc