### PR TITLE
Refactor prompt editing logic

### DIFF
--- a/src/lib/UserInteraction/PromptEditor.ts
+++ b/src/lib/UserInteraction/PromptEditor.ts
@@ -1,0 +1,170 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import fs from 'fs/promises';
+import crypto from 'crypto';
+import chalk from 'chalk';
+import { FileSystem } from '../FileSystem';
+import { toSnakeCase } from '../utils';
+import { Config } from '../Config';
+import { Message } from '../models/Conversation';
+
+export const HISTORY_SEPARATOR = '--- TYPE YOUR PROMPT ABOVE THIS LINE ---';
+
+export interface PromptResult {
+    newPrompt: string | null;
+    conversationFilePath: string;
+    editorFilePath: string;
+}
+
+export class PromptEditor {
+    private fs: FileSystem;
+    private config: Config;
+
+    constructor(fs: FileSystem, config: Config) {
+        this.fs = fs;
+        this.config = config;
+    }
+
+    formatHistoryForSublime(messages: Message[]): string {
+        let historyBlock = '';
+        for (let i = messages.length - 1; i >= 0; i--) {
+            const msg = messages[i];
+            const timestampStr = msg.timestamp ? new Date(msg.timestamp).toLocaleString() : 'Unknown Time';
+            const roleLabel = msg.role === 'user' ? 'User' : msg.role === 'assistant' ? 'LLM' : 'System';
+            historyBlock += `${roleLabel}: [${timestampStr}]\n\n`;
+            historyBlock += `${msg.content.trim()}\n\n`;
+        }
+        if (historyBlock) {
+            return `\n\n${HISTORY_SEPARATOR}\n\n${historyBlock.trimEnd()}`;
+        } else {
+            return `${HISTORY_SEPARATOR}\n\n`;
+        }
+    }
+
+    extractNewPrompt(fullContent: string): string | null {
+        const separatorIndex = fullContent.indexOf(HISTORY_SEPARATOR);
+        let promptRaw: string;
+        if (separatorIndex !== -1) {
+            promptRaw = fullContent.substring(0, separatorIndex);
+        } else {
+            console.warn(chalk.yellow('Warning: History separator not found in editor file. Treating entire content as prompt.'));
+            promptRaw = fullContent;
+        }
+        const promptTrimmed = promptRaw.trim();
+        return promptTrimmed ? promptTrimmed : null;
+    }
+
+    async getPromptViaSublimeLoop(
+        conversationName: string,
+        currentMessages: Message[],
+        editorFilePath: string,
+        isFallbackAttempt = false
+    ): Promise<PromptResult> {
+        const conversationFileName = `${toSnakeCase(conversationName)}.jsonl`;
+        const conversationFilePath = path.join(this.config.chatsDir, conversationFileName);
+        const contentToWrite = this.formatHistoryForSublime(currentMessages || []);
+        const initialHash = crypto.createHash('sha256').update(contentToWrite).digest('hex');
+        try {
+            await this.fs.writeFile(editorFilePath, contentToWrite);
+        } catch (writeError) {
+            console.error(`Error writing temporary edit file ${editorFilePath}:`, writeError);
+            throw writeError;
+        }
+
+        let editorCommand = 'subl';
+        let editorArgs = ['-w', editorFilePath];
+        let editorName = 'Sublime Text';
+        if (process.platform === 'darwin' && !isFallbackAttempt) {
+            const bundleId = process.env.__CFBundleIdentifier;
+            if (bundleId === 'com.jetbrains.WebStorm') {
+                editorCommand = 'webstorm';
+                editorArgs = ['--wait', editorFilePath];
+                editorName = 'WebStorm';
+                console.log(chalk.blue(`Detected running inside WebStorm (macOS). Using '${editorCommand}' command...`));
+            } else if (bundleId === 'com.jetbrains.CLion') {
+                editorCommand = 'clion';
+                editorArgs = ['--wait', editorFilePath];
+                editorName = 'CLion';
+                console.log(chalk.blue(`Detected running inside CLion (macOS). Using '${editorCommand}' command...`));
+            } else if (bundleId === 'com.jetbrains.intellij') {
+                editorCommand = 'idea';
+                editorArgs = ['--wait', editorFilePath];
+                editorName = 'IntelliJ IDEA';
+                console.log(chalk.blue(`Detected running inside IntelliJ IDEA (macOS). Using '${editorCommand}' command...`));
+            }
+        }
+
+        console.log(`\nOpening conversation "${conversationName}" in ${editorName}...`);
+        console.log(`(Type your prompt above the '${HISTORY_SEPARATOR}', save, and close the editor tab/window to send)`);
+        console.log(`(Close without saving OR save without changes to exit conversation)`);
+
+        let exitCode: number | null = null;
+        let processError: any = null;
+        try {
+            const editorProcess = spawn(editorCommand, editorArgs, { stdio: 'inherit' });
+            exitCode = await new Promise<number | null>((resolve, reject) => {
+                editorProcess.on('close', code => resolve(code));
+                editorProcess.on('error', error => {
+                    if ((error as any).code === 'ENOENT') {
+                        const errorMsg = `❌ Error: '${editorCommand}' command not found.`;
+                        const isJetBrainsLauncher = ['webstorm', 'clion', 'idea'].includes(editorCommand);
+                        if (isJetBrainsLauncher && !isFallbackAttempt) {
+                            console.error(chalk.red(`\n${errorMsg} Ensure the JetBrains IDE command-line launcher ('${editorCommand}') is created (Tools -> Create Command-line Launcher...) and its directory is in your system's PATH.`));
+                            console.warn(chalk.yellow(`Falling back to 'subl'...`));
+                            reject({ type: 'fallback', editor: 'subl', args: ['-w', editorFilePath] });
+                        } else {
+                            console.error(chalk.red(`\n${errorMsg} Make sure ${editorName} is installed and '${editorCommand}' is in your system's PATH.`));
+                            reject(new Error(`'${editorCommand}' command not found.`));
+                        }
+                    } else {
+                        console.error(chalk.red(`\n❌ Error spawning ${editorName}:`), error);
+                        reject(error);
+                    }
+                });
+            });
+        } catch (err: any) {
+            processError = err;
+        }
+
+        if (processError && processError.type === 'fallback') {
+            console.log(chalk.blue(`Attempting to open with fallback editor: ${processError.editor}...`));
+            return this.getPromptViaSublimeLoop(conversationName, currentMessages, editorFilePath, true);
+        } else if (processError) {
+            throw processError;
+        }
+
+        if (exitCode !== 0) {
+            console.warn(chalk.yellow(`\n${editorName} process closed with non-zero code: ${exitCode}. Assuming exit.`));
+            return { newPrompt: null, conversationFilePath, editorFilePath };
+        }
+
+        let modifiedContent: string;
+        try {
+            await fs.access(editorFilePath);
+            modifiedContent = (await this.fs.readFile(editorFilePath)) || '';
+        } catch (readError: any) {
+            if (readError.code === 'ENOENT') {
+                console.warn(chalk.yellow(`\nEditor file ${editorFilePath} not found after closing ${editorName}. Assuming exit.`));
+                return { newPrompt: null, conversationFilePath, editorFilePath };
+            }
+            console.error(chalk.red(`\nError reading editor file ${editorFilePath} after closing:`), readError);
+            throw readError;
+        }
+
+        const modifiedHash = crypto.createHash('sha256').update(modifiedContent).digest('hex');
+        if (initialHash === modifiedHash) {
+            console.log(chalk.blue(`\nNo changes detected in ${editorName}. Exiting conversation.`));
+            return { newPrompt: null, conversationFilePath, editorFilePath };
+        }
+
+        const newPrompt = this.extractNewPrompt(modifiedContent);
+        if (newPrompt === null) {
+            console.log(chalk.blue(`\nNo new prompt entered. Exiting conversation.`));
+            return { newPrompt: null, conversationFilePath, editorFilePath };
+        }
+
+        console.log(chalk.green(`\nPrompt received, processing with AI...`));
+        return { newPrompt, conversationFilePath, editorFilePath };
+    }
+}
+

--- a/src/lib/UserInteraction/__tests__/PromptEditor.test.ts
+++ b/src/lib/UserInteraction/__tests__/PromptEditor.test.ts
@@ -1,0 +1,188 @@
+import { PromptEditor, HISTORY_SEPARATOR } from '../PromptEditor';
+import { FileSystem } from '../../FileSystem';
+
+jest.mock('chalk');
+
+describe('PromptEditor', () => {
+  describe('formatHistoryForSublime and extractNewPrompt', () => {
+    it('formats history for Sublime correctly', () => {
+      const fs = new FileSystem();
+      const editor = new PromptEditor(fs as any, { chatsDir: '' } as any);
+      const msgs = [
+        { role: 'user', content: 'first', timestamp: '2020-01-01T00:00:00Z' },
+        { role: 'assistant', content: 'second', timestamp: '2020-01-02T00:00:00Z' }
+      ];
+      const out = editor.formatHistoryForSublime(msgs as any);
+      expect(out).toContain('TYPE YOUR PROMPT ABOVE THIS LINE');
+      expect(out).toContain('User:');
+      expect(out).toContain('LLM:');
+    });
+
+    it('extracts new prompt correctly when separator is present', () => {
+      const fs = new FileSystem();
+      const editor = new PromptEditor(fs as any, { chatsDir: '' } as any);
+      const text = `hello\n${HISTORY_SEPARATOR}\nold`;
+      expect(editor.extractNewPrompt(text)).toBe('hello');
+    });
+
+    it('returns null when no prompt is entered', () => {
+      const fs = new FileSystem();
+      const editor = new PromptEditor(fs as any, { chatsDir: '' } as any);
+      expect(editor.extractNewPrompt(`    \n${HISTORY_SEPARATOR}\n`)).toBeNull();
+    });
+
+    it('warns when separator missing', () => {
+      const fs = new FileSystem();
+      const editor = new PromptEditor(fs as any, { chatsDir: '' } as any);
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(editor.extractNewPrompt('hello')).toBe('hello');
+      expect(warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('getPromptViaSublimeLoop', () => {
+    let editor: PromptEditor;
+    beforeEach(() => {
+      jest.resetAllMocks();
+      const fsInst = new FileSystem();
+      editor = new PromptEditor(fsInst as any, { chatsDir: '/chats', context: {} } as any);
+      jest.spyOn(fsInst, 'writeFile').mockResolvedValue(undefined as any);
+      jest.spyOn(fsInst, 'readFile');
+      jest.spyOn(console, 'log').mockImplementation(() => {});
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+      jest.spyOn(require('fs/promises'), 'access').mockResolvedValue(undefined);
+    });
+    afterEach(() => jest.unmock('child_process'));
+
+    it('returns null when editor close code != 0', async () => {
+      const fakeSpawn = { on: (_: string, cb: any) => cb(1) } as any;
+      jest.spyOn(require('child_process'), 'spawn').mockReturnValue(fakeSpawn);
+      const result = await editor.getPromptViaSublimeLoop('conv', [], '/tmp/edit');
+      expect(result.newPrompt).toBeNull();
+    });
+
+    it('returns extracted prompt when content changed', async () => {
+      const modified = `new prompt\n${HISTORY_SEPARATOR}\nhist`;
+      (editor as any).fs.readFile.mockResolvedValue(modified);
+      const fakeSpawn = { on: (_: string, cb: any) => cb(0) } as any;
+      jest.spyOn(require('child_process'), 'spawn').mockReturnValue(fakeSpawn);
+      const res = await editor.getPromptViaSublimeLoop('conv', [], '/tmp/edit');
+      expect(res.newPrompt).toBe('new prompt');
+    });
+
+    it('falls back from JetBrains IDE to Sublime when spawn errors ENOENT', async () => {
+      const error = { code: 'ENOENT' };
+      let call = 0;
+      jest.spyOn(require('child_process'), 'spawn').mockImplementation(() => {
+        call++;
+        if (call === 1) throw error;
+        return { on: (_: string, cb: any) => cb(0) } as any;
+      });
+      (editor as any).fs.readFile.mockResolvedValue(`p\n${HISTORY_SEPARATOR}`);
+      await expect(editor.getPromptViaSublimeLoop('c', [], '/tmp/e')).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('retries with Sublime and succeeds when JetBrains launcher fails', async () => {
+      const error = { code: 'ENOENT' };
+      let call = 0;
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      process.env.__CFBundleIdentifier = 'com.jetbrains.WebStorm';
+      jest.spyOn(require('child_process'), 'spawn').mockImplementation(() => {
+        call++;
+        return {
+          on: (ev: string, cb: any) => {
+            if (call === 1 && ev === 'error') cb(error);
+            if (call === 2 && ev === 'close') cb(0);
+          },
+        } as any;
+      });
+      (editor as any).fs.readFile.mockResolvedValue(`np\n${HISTORY_SEPARATOR}`);
+      const logSpy = console.log as jest.Mock;
+      const res = await editor.getPromptViaSublimeLoop('c', [], '/tmp/edit');
+      expect(res.newPrompt).toBe('np');
+      expect(call).toBe(2);
+      expect(logSpy).toHaveBeenCalled();
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      delete process.env.__CFBundleIdentifier;
+    });
+
+    it('throws error when fallback editor is also missing', async () => {
+      const error = { code: 'ENOENT' };
+      let call = 0;
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      process.env.__CFBundleIdentifier = 'com.jetbrains.WebStorm';
+      jest.spyOn(require('child_process'), 'spawn').mockImplementation(() => {
+        call++;
+        return {
+          on: (ev: string, cb: any) => {
+            if (ev === 'error') cb(error);
+          },
+        } as any;
+      });
+      (editor as any).fs.readFile.mockResolvedValue(`x\n${HISTORY_SEPARATOR}`);
+      await expect(editor.getPromptViaSublimeLoop('c', [], '/tmp/edit')).rejects.toThrow();
+      expect(call).toBe(2);
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      delete process.env.__CFBundleIdentifier;
+    });
+  });
+
+  describe('additional getPromptViaSublimeLoop flows', () => {
+    let editor: PromptEditor;
+    beforeEach(() => {
+      jest.resetAllMocks();
+      const fsInst = new FileSystem();
+      editor = new PromptEditor(fsInst as any, { chatsDir: '/chats', context: {} } as any);
+      jest.spyOn(console, 'log').mockImplementation(() => {});
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    it('handles missing editor file', async () => {
+      const fsInst = (editor as any).fs;
+      jest.spyOn(fsInst, 'writeFile').mockResolvedValue(undefined as any);
+      jest.spyOn(require('child_process'), 'spawn').mockReturnValue({ on: (e: string, cb: any) => e === 'close' && cb(0) } as any);
+      jest.spyOn(require('fs/promises'), 'access').mockRejectedValue(Object.assign(new Error('x'), { code: 'ENOENT' }));
+      const res = await editor.getPromptViaSublimeLoop('c', [], '/tmp/edit');
+      expect(res.newPrompt).toBeNull();
+    });
+
+    it('returns null when no changes made', async () => {
+      const fsInst = (editor as any).fs;
+      let content = '';
+      jest.spyOn(fsInst, 'writeFile').mockImplementation((_f, d) => { content = d as any; return Promise.resolve(); });
+      jest.spyOn(require('fs/promises'), 'access').mockResolvedValue(undefined);
+      jest.spyOn(fsInst, 'readFile').mockImplementation(async () => content);
+      jest.spyOn(require('child_process'), 'spawn').mockReturnValue({ on: (e: string, cb: any) => e === 'close' && cb(0) } as any);
+      const res = await editor.getPromptViaSublimeLoop('c', [], '/tmp/edit');
+      expect(res.newPrompt).toBeNull();
+    });
+
+    it('returns null when no prompt extracted', async () => {
+      const fsInst = (editor as any).fs;
+      jest.spyOn(fsInst, 'writeFile').mockResolvedValue(undefined as any);
+      jest.spyOn(fsInst, 'readFile').mockResolvedValue(`   \n${HISTORY_SEPARATOR}\nold`);
+      jest.spyOn(require('fs/promises'), 'access').mockResolvedValue(undefined);
+      jest.spyOn(require('child_process'), 'spawn').mockReturnValue({ on: (e: string, cb: any) => e === 'close' && cb(0) } as any);
+      const res = await editor.getPromptViaSublimeLoop('c', [], '/tmp/edit');
+      expect(res.newPrompt).toBeNull();
+    });
+
+    it('throws when readFile fails unexpectedly', async () => {
+      const fsInst = (editor as any).fs;
+      jest.spyOn(fsInst, 'writeFile').mockResolvedValue(undefined as any);
+      jest.spyOn(require('fs/promises'), 'access').mockResolvedValue(undefined);
+      jest.spyOn(fsInst, 'readFile').mockRejectedValue(new Error('boom'));
+      jest.spyOn(require('child_process'), 'spawn').mockReturnValue({ on: (e: string, cb: any) => e === 'close' && cb(0) } as any);
+      await expect(editor.getPromptViaSublimeLoop('c', [], '/tmp/edit')).rejects.toThrow('boom');
+    });
+
+    it('throws when writeFile fails', async () => {
+      const fsInst = (editor as any).fs;
+      jest.spyOn(fsInst, 'writeFile').mockRejectedValue(new Error('fail'));
+      jest.spyOn(require('child_process'), 'spawn').mockReturnValue({ on: (e: string, cb: any) => e === 'close' && cb(0) } as any);
+      await expect(editor.getPromptViaSublimeLoop('c', [], '/tmp/edit')).rejects.toThrow('fail');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- create `PromptEditor` class for opening prompts in the editor
- delegate prompt editing logic from `UserInterface` to `PromptEditor`
- break out deletion, scaffold and harden handlers in `UserInterface`
- add tests for `PromptEditor` and update `UserInterface` tests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68625733103c8330a0fab0037385c939