### PR TITLE
Use OpenAI diffs when configured

### DIFF
--- a/src/lib/DiffApplier.ts
+++ b/src/lib/DiffApplier.ts
@@ -14,11 +14,6 @@ export async function applyDiffIteratively(
     diff: string,
     maxAttempts = 10
 ): Promise<boolean> {
-    // Always request corrected diffs from the Gemini Pro model (gemini-2.5-pro)
-    // because it generally produces higher-quality patches than the cheaper
-    // Flash model.  The boolean flag is inverted in AIClient: `false` chooses
-    // the primary/pro model.
-    const USE_PRO_MODEL = false;
     let currentDiff = diff;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
         if (currentDiff.trim().length === 0) {
@@ -59,7 +54,8 @@ export async function applyDiffIteratively(
         try {
             currentDiff = await ai.getResponseTextFromAI(
                 [{ role: 'user', content: prompt }],
-                USE_PRO_MODEL
+                false,
+                true
             );
         } catch (err) {
             console.error(chalk.red('Failed to get corrected diff from AI:'), err);

--- a/src/lib/__tests__/DiffApplier.test.ts
+++ b/src/lib/__tests__/DiffApplier.test.ts
@@ -60,7 +60,9 @@ describe('applyDiffIteratively', () => {
     expect(fsMock.applyDiffToFile).toHaveBeenNthCalledWith(1, filePath, initialDiff);
     expect(fsMock.applyDiffToFile).toHaveBeenNthCalledWith(2, filePath, correctedDiff);
     expect(aiMock.getResponseTextFromAI).toHaveBeenCalledTimes(1);
-    expect(aiMock.getResponseTextFromAI).toHaveBeenCalledWith([{ role: 'user', content: DiffFixPrompts.fixPatch(filePath, 'old-content', initialDiff, 'Patch failed') }], false);
+    expect(aiMock.getResponseTextFromAI).toHaveBeenCalledWith([
+      { role: 'user', content: DiffFixPrompts.fixPatch(filePath, 'old-content', initialDiff, 'Patch failed') }
+    ], false, true);
     expect(logDiffFailure).toHaveBeenCalledTimes(0); // Should not log failure to file if eventually successful
   });
 
@@ -136,7 +138,7 @@ describe('applyDiffIteratively', () => {
     expect(fsMock.readFile).toHaveBeenCalledWith(filePath);
     expect(aiMock.getResponseTextFromAI).toHaveBeenCalledWith([
       { role: 'user', content: DiffFixPrompts.fixPatch(filePath, '', initialDiff, '') }
-    ], false);
+    ], false, true);
     expect(fsMock.applyDiffToFile).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Summary
- enable OpenAI diff use automatically when API key present
- expose `useOpenAIDiffs` flag in `AIClient`
- allow requesting OpenAI in `getResponseTextFromAI`
- default diff fixer to request OpenAI
- update diff applier tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68628e997f1c83308481606db9d5004a