### PR TITLE
Add anthropic model to model selection

### DIFF
--- a/src/lib/UserInterface.ts
+++ b/src/lib/UserInterface.ts
@@ -276,6 +276,13 @@ class UserInterface {
                 value: secondaryModel,
             },
         ];
+        const anthropicModel = this.config.anthropic?.model_name;
+        if (anthropicModel) {
+            modelChoices.push({
+                name: `Anthropic Model (${anthropicModel}) - Claude from Anthropic`,
+                value: anthropicModel,
+            });
+        }
         const { modelChoice } = await inquirer.prompt([
             {
                 type: 'list',
@@ -390,6 +397,13 @@ class UserInterface {
                     value: secondaryModel
                 },
             ];
+            const anthropicModel = this.config.anthropic?.model_name;
+            if (anthropicModel) {
+                modelChoices.push({
+                    name: `Anthropic Model (${anthropicModel}) - Claude from Anthropic`,
+                    value: anthropicModel
+                });
+            }
 
             const { modelChoice } = await inquirer.prompt([
                 {

--- a/src/lib/__tests__/UserInterface.test.ts
+++ b/src/lib/__tests__/UserInterface.test.ts
@@ -379,5 +379,23 @@ describe('UserInterface', () => {
       const res = await ui.getUserInteraction();
       expect(res).toEqual({ mode: 'Consolidate Changes...', conversationName: 'c', isNewConversation: false, selectedModel: 'm1' });
     });
+
+    it('includes anthropic model option when configured', async () => {
+      const configWithClaude = {
+        ...baseConfig,
+        anthropic: { api_key: 'key', model_name: 'claude' }
+      } as any;
+      ui = new UserInterface(configWithClaude);
+      jest.spyOn(ui.fs, 'ensureKaiDirectoryExists').mockResolvedValue(undefined);
+      jest.spyOn(ui, 'selectOrCreateConversation').mockResolvedValue({ name: 'c', isNew: false });
+      (inquirer.prompt as jest.Mock)
+        .mockResolvedValueOnce({ mode: 'Start/Continue Conversation' })
+        .mockImplementationOnce(async qs => {
+          expect(qs[0].choices.map((c: any) => c.value)).toContain('claude');
+          return { modelChoice: 'claude' };
+        });
+      const res = await ui.getUserInteraction();
+      expect(res).toEqual({ mode: 'Start/Continue Conversation', conversationName: 'c', isNewConversation: false, selectedModel: 'claude' });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- allow UserInterface to show the Anthropic Claude model when present in config
- test that the model choice list includes Claude

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68721d239bfc83308a957d727ff71d27