### PR TITLE
Add Anthropic SDK dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Use this commit message? (Y/n) y
     *   **JetBrains IDEs (Experimental):** Requires the command-line launcher to be created (e.g., via `Tools -> Create Command-line Launcher...` in the IDE) and the launcher's directory added to your system's PATH. Kai attempts to detect `webstorm`, `clion`, `idea`, etc., on macOS.
     *   Other editors might work if they have a CLI command that waits for the file to be closed.
 *   **Google Gemini API Key:** Required for the AI interactions.
+*   **Anthropic API Key:** *(optional)* Needed to use Anthropic Claude models.
 
 ### Steps
 
@@ -95,6 +96,19 @@ Use this commit message? (Y/n) y
     $env:GEMINI_API_KEY = 'YOUR_API_KEY_HERE'
     ```
     *Tip: Use tools like `dotenv` or your shell's profile configuration for managing environment variables easily.*
+
+3.  **Set Anthropic API Key (Optional):**
+    Kai reads the API key from the `ANTHROPIC_API_KEY` environment variable if you plan to use Anthropic Claude models.
+    ```bash
+    # On Linux/macOS
+    export ANTHROPIC_API_KEY='YOUR_API_KEY_HERE'
+
+    # On Windows (Command Prompt)
+    set ANTHROPIC_API_KEY=YOUR_API_KEY_HERE
+
+    # On Windows (PowerShell)
+    $env:ANTHROPIC_API_KEY = 'YOUR_API_KEY_HERE'
+    ```
 
 ### Development Setup (From Source)
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/nodesman/kai#readme",
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
+    "@anthropic-ai/sdk": "^0.56.0",
     "chalk": "^5.4.1",
     "cli-table3": "^0.6.5",
     "diff": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,11 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@anthropic-ai/sdk@^0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.56.0.tgz#8b6366d5d22235c3ec978c05b2c9420fdf426ed9"
+  integrity sha512-SLCB8M8+VMg1cpCucnA1XWHGWqVSZtIWzmOdDOEu3eTFZMB+A0sGZ1ESO5MHDnqrNTXz3safMrWx9x4rMZSOqA==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.26.2":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"


### PR DESCRIPTION
## Summary
- add `@anthropic-ai/sdk` to dependencies and lock file
- document Anthropic API key requirement in setup instructions

## Testing
- `yarn install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878fe5763348330afedae8a884ebb56