### PR TITLE
Fix GPT-o3 selection

### DIFF
--- a/src/lib/AIClient.ts
+++ b/src/lib/AIClient.ts
@@ -51,6 +51,7 @@ class AIClient {
         if ((config as any).openai?.api_key) {
             this.openAIModels['gpt-4o'] = new OpenAIChatModel(config, 'gpt-4o');
             this.openAIModels['o3'] = new OpenAIChatModel(config, 'o3');
+            this.openAIModels['gpt-o3'] = new OpenAIChatModel(config, 'gpt-o3');
         }
         this.fs = new FileSystem();
     }


### PR DESCRIPTION
## Summary
- register `gpt-o3` in `AIClient` when OpenAI API key is available

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889b5a666908330b862702873ae77f1